### PR TITLE
fix(auth): show login error feedback

### DIFF
--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -46,9 +46,12 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
   const [emailConfirmationMessage] = useState<EmailConfirmationMessage | null>(
     getInitialEmailConfirmationMessage
   );
+
+  const visibleError = authError ?? submitError;
 
   useEffect(() => {
     if (emailConfirmationMessage?.show) {
@@ -57,36 +60,63 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
     }
   }, [emailConfirmationMessage?.show]);
 
+
+  const getValidationError = () => {
+    const email = formData.email.trim();
+    const password = formData.password;
+
+    if (!email && !password) {
+      return 'Ingresa tu email y contraseña.';
+    }
+
+    if (!email) {
+      return 'El email es requerido.';
+    }
+
+    if (!password) {
+      return 'La contraseña es requerida.';
+    }
+
+    return null;
+  };
+
   // Auto-scroll global para inputs en móvil (ahora usando hook reutilizable)
   useMobileInputAutoScroll();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitError(null);
     clearAuthError();
-    setLoading(true);
 
-    if (!formData.email || !formData.password) {
-      // For validation errors, we can still use a local approach or set in context
-      // For now keeping it simple with a check that prevents submission
-      setLoading(false);
+    const validationError = getValidationError();
+    if (validationError) {
+      setSubmitError(validationError);
       return;
     }
 
+    setLoading(true);
+
     try {
       const result = await signIn(
-        formData.email,
+        formData.email.trim(),
         formData.password,
         rememberMe
       );
 
       if (!result.error) {
-        setLoading(false);
         onSuccess?.();
         router.push('/');
-      } else {
-        setLoading(false);
+        return;
       }
-    } catch (err) {
+
+      setSubmitError(
+        'No pudimos iniciar sesión. Revisá tus datos e intentá nuevamente.'
+      );
+    } catch {
+      setSubmitError(
+        'Ocurrió un error inesperado al iniciar sesión. Intentá de nuevo.'
+      );
+    } finally {
       setLoading(false);
     }
   };
@@ -94,6 +124,11 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
+
+    if (submitError) {
+      setSubmitError(null);
+    }
+
     // Clear error when user starts typing
     if (authError) clearAuthError();
   };
@@ -155,21 +190,23 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
           </motion.div>
         )}
 
-        {authError && (
+        {visibleError && (
           <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             className="mb-6 rounded-xl border-2 border-destructive/20 bg-destructive/10 p-5"
+            role="alert"
+            aria-live="assertive"
           >
             <div className="flex items-start space-x-3">
               <AlertCircle className="mt-0.5 h-6 w-6 flex-shrink-0 text-destructive" />
               <div className="flex-1">
                 <p className="mb-2 font-semibold text-destructive">
-                  {authError}
+                  {visibleError}
                 </p>
-                {authError.includes('confirmado') ||
-                authError.includes('verificar') ||
-                authError.includes('Email') ? (
+                {visibleError.includes('confirmado') ||
+                visibleError.includes('verificar') ||
+                visibleError.includes('Email') ? (
                   <div className="mt-3 rounded-lg border border-primary/20 bg-primary/10 p-3">
                     <p className="mb-2 text-sm font-medium text-primary">
                       📧 ¿No recibiste el correo de verificación?

--- a/tests/components/login-form.test.tsx
+++ b/tests/components/login-form.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LoginForm } from '@/components/auth/login-form';
+import { useAuth } from '@/hooks/use-auth';
+
+const mockPush = jest.fn();
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockSignIn = jest.fn();
+const mockClearAuthError = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      transition: _transition,
+      whileHover: _whileHover,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      initial?: unknown;
+      animate?: unknown;
+      transition?: unknown;
+      whileHover?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@/hooks', () => ({
+  useMobileInputAutoScroll: jest.fn(),
+}));
+
+jest.mock('@/components/ui', () => ({
+  Button: ({ children, icon, loading: _loading, ...props }: any) => (
+    <button {...props}>
+      {icon}
+      {children}
+    </button>
+  ),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    ...props
+  }: {
+    checked: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+  } & React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input
+      {...props}
+      type="checkbox"
+      checked={checked}
+      onChange={(event) => onCheckedChange?.(event.target.checked)}
+    />
+  ),
+}));
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSignIn.mockResolvedValue({ error: null });
+    mockUseAuth.mockReturnValue({
+      signIn: mockSignIn,
+      authError: null,
+      clearAuthError: mockClearAuthError,
+    } as ReturnType<typeof useAuth>);
+  });
+
+  it('shows explicit validation when email and password are missing', () => {
+    render(<LoginForm />);
+
+    const submitButton = screen.getByRole('button', {
+      name: /iniciar sesión/i,
+    });
+    const form = submitButton.closest('form');
+
+    if (!form) {
+      throw new Error('Login form not found');
+    }
+
+    fireEvent.submit(form);
+
+    expect(mockSignIn).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Ingresa tu email y contraseña.'
+    );
+  });
+
+  it('renders auth-context login errors visibly for the user', () => {
+    mockUseAuth.mockReturnValue({
+      signIn: mockSignIn,
+      authError: 'Credenciales incorrectas. Verifica tu email y contraseña.',
+      clearAuthError: mockClearAuthError,
+    } as ReturnType<typeof useAuth>);
+
+    render(<LoginForm />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Credenciales incorrectas. Verifica tu email y contraseña.'
+    );
+  });
+
+  it('shows a fallback error when signIn returns an error without a visible auth message', async () => {
+    const user = userEvent.setup();
+    mockSignIn.mockResolvedValue({
+      error: { message: 'Invalid login credentials' },
+    });
+
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/contraseña/i), 'secret123');
+    await user.click(screen.getByRole('button', { name: /iniciar sesión/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'No pudimos iniciar sesión. Revisá tus datos e intentá nuevamente.'
+    );
+  });
+
+  it('shows a fallback error when submit throws unexpectedly', async () => {
+    const user = userEvent.setup();
+    mockSignIn.mockRejectedValue(new Error('network down'));
+
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText(/email/i), 'test@example.com');
+    await user.type(screen.getByLabelText(/contraseña/i), 'secret123');
+    await user.click(screen.getByRole('button', { name: /iniciar sesión/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Ocurrió un error inesperado al iniciar sesión. Intentá de nuevo.'
+    );
+  });
+});


### PR DESCRIPTION
Closes #3

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- restore visible login feedback for invalid credentials and other submit failures
- add explicit validation messages for missing email/password
- add focused regression tests for login error rendering

## Changes
| File | Change |
|------|--------|
| `components/auth/login-form.tsx` | Adds explicit validation and fallback error rendering for login submit failures |
| `tests/components/login-form.test.tsx` | Adds regression coverage for missing fields, incorrect credentials, returned errors, and thrown submit failures |

## Test Plan
- [x] `npm run test -- --runInBand --runTestsByPath tests/components/login-form.test.tsx`
- [x] `npm run type-check`
- [x] `npm run lint`
- [ ] `npm run build` in clean worktree (blocked by Turbopack rejecting the temporary `node_modules` junction used for isolated worktrees)

## Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Used a conventional commit
- [x] Added regression tests for the bug fix
- [x] No Co-Authored-By trailers