### PR TITLE
fix(debts): exclude debts from available balances

### DIFF
--- a/.gga
+++ b/.gga
@@ -1,7 +1,7 @@
 # Gentleman Guardian Angel config for FinTec
 # https://github.com/Gentleman-Programming/gentleman-guardian-angel
 
-PROVIDER="opencode:google/gemini-3-flash-preview"
+PROVIDER="opencode:opencode/deepseek-v4-flash-free"
 FILE_PATTERNS="*.ts,*.tsx,*.js,*.jsx"
 EXCLUDE_PATTERNS="*.test.ts,*.spec.ts,*.test.tsx,*.d.ts,*.mjs,*.cjs"
 RULES_FILE="AGENTS.md"

--- a/components/forms/transaction-form.tsx
+++ b/components/forms/transaction-form.tsx
@@ -293,12 +293,12 @@ export function TransactionForm({
         // `sourceAccountId` so the DTO does not carry a stale value.
         deductFromAccount:
           canShowDebtFields && formData.isDebt
-            ? formData.deductFromAccount
+            ? shouldDeductFromAccount
             : undefined,
         sourceAccountId:
           canShowDebtFields &&
           formData.isDebt &&
-          formData.deductFromAccount &&
+          shouldDeductFromAccount &&
           formData.sourceAccountId
             ? formData.sourceAccountId
             : undefined,
@@ -367,6 +367,9 @@ export function TransactionForm({
           acc.id !== selectedDebtAccount.id
       )
     : [];
+  const hasEligibleSourceAccounts = eligibleSourceAccounts.length > 0;
+  const shouldDeductFromAccount =
+    formData.deductFromAccount && hasEligibleSourceAccounts;
 
   // Transform data for Select components
   const accountOptions = accounts.map((account) => ({
@@ -630,8 +633,8 @@ export function TransactionForm({
                   <input
                     id="transaction-deduct-from-account"
                     type="checkbox"
-                    checked={formData.deductFromAccount}
-                    disabled={eligibleSourceAccounts.length === 0}
+                    checked={shouldDeductFromAccount}
+                    disabled={!hasEligibleSourceAccounts}
                     onChange={(e) =>
                       setFormData((prev) => ({
                         ...prev,
@@ -646,12 +649,12 @@ export function TransactionForm({
                     className="h-5 w-5 rounded border-border/30 bg-card/60 disabled:opacity-50"
                   />
                 </div>
-                {eligibleSourceAccounts.length === 0 ? (
+                {!hasEligibleSourceAccounts ? (
                   <p className="text-ios-caption text-muted-foreground">
                     No tienes otra cuenta en la misma moneda para descontar.
                   </p>
                 ) : (
-                  formData.deductFromAccount && (
+                  shouldDeductFromAccount && (
                     <Select
                       label="Cuenta de origen"
                       value={formData.sourceAccountId}

--- a/components/forms/transaction-form.tsx
+++ b/components/forms/transaction-form.tsx
@@ -104,6 +104,11 @@ export function TransactionForm({
     settledAt: transaction?.settledAt
       ? transaction.settledAt.split('T')[0]
       : '',
+    // * Debt-only: when true (default), the repository will create a
+    // linked EXPENSE that debits `sourceAccountId` atomically with the
+    // debt row. When false, the debt is metadata only.
+    deductFromAccount: true,
+    sourceAccountId: '',
   });
 
   const [loading, setLoading] = useState(false);
@@ -152,6 +157,8 @@ export function TransactionForm({
         settledAt: transaction.settledAt
           ? transaction.settledAt.split('T')[0]
           : '',
+        deductFromAccount: true,
+        sourceAccountId: '',
       });
     } else if (debtMode === 'create') {
       // Pre-fill for debt creation mode
@@ -169,6 +176,8 @@ export function TransactionForm({
         debtStatus: DebtStatus.OPEN,
         counterpartyName: '',
         settledAt: '',
+        deductFromAccount: true,
+        sourceAccountId: '',
       });
     } else {
       setFormData({
@@ -185,6 +194,8 @@ export function TransactionForm({
         debtStatus: DebtStatus.OPEN,
         counterpartyName: '',
         settledAt: '',
+        deductFromAccount: true,
+        sourceAccountId: '',
       });
     }
   }, [transaction, type, debtMode]);
@@ -277,6 +288,20 @@ export function TransactionForm({
           formData.debtStatus === DebtStatus.SETTLED
             ? new Date(formData.settledAt).toISOString()
             : undefined,
+        // * Debt-only: forward the deduct toggle and the picked source
+        // account. When the toggle is off we deliberately omit
+        // `sourceAccountId` so the DTO does not carry a stale value.
+        deductFromAccount:
+          canShowDebtFields && formData.isDebt
+            ? formData.deductFromAccount
+            : undefined,
+        sourceAccountId:
+          canShowDebtFields &&
+          formData.isDebt &&
+          formData.deductFromAccount &&
+          formData.sourceAccountId
+            ? formData.sourceAccountId
+            : undefined,
       };
 
       if (transaction) {
@@ -316,6 +341,8 @@ export function TransactionForm({
         debtStatus: DebtStatus.OPEN,
         counterpartyName: '',
         settledAt: '',
+        deductFromAccount: true,
+        sourceAccountId: '',
       });
     } catch (error) {
       toast.error('Error al guardar la transaccion');
@@ -326,8 +353,28 @@ export function TransactionForm({
 
   const selectedType = transactionTypes.find((t) => t.value === formData.type);
 
+  // The "main" account drives the debt's transaction currency, which in
+  // turn filters the source-account picker. The picker only shows accounts
+  // in the SAME currency so the linked EXPENSE debits the right one.
+  const selectedDebtAccount = accounts.find(
+    (acc) => acc.id === formData.accountId
+  );
+  const eligibleSourceAccounts = selectedDebtAccount
+    ? accounts.filter(
+        (acc) =>
+          acc.active &&
+          acc.currencyCode === selectedDebtAccount.currencyCode &&
+          acc.id !== selectedDebtAccount.id
+      )
+    : [];
+
   // Transform data for Select components
   const accountOptions = accounts.map((account) => ({
+    value: account.id,
+    label: `${account.name} (${account.currencyCode})`,
+  }));
+
+  const sourceAccountOptions = eligibleSourceAccounts.map((account) => ({
     value: account.id,
     label: `${account.name} (${account.currencyCode})`,
   }));
@@ -568,6 +615,60 @@ export function TransactionForm({
                   ]}
                   required
                 />
+
+                {/* * Debt-only: "Deduct from account" toggle + currency-
+                    filtered source-account picker. The picker is disabled
+                    when no eligible account exists for the chosen main
+                    account's currency. */}
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor="transaction-deduct-from-account"
+                    className="text-ios-body font-medium text-foreground"
+                  >
+                    Descontar de cuenta
+                  </label>
+                  <input
+                    id="transaction-deduct-from-account"
+                    type="checkbox"
+                    checked={formData.deductFromAccount}
+                    disabled={eligibleSourceAccounts.length === 0}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        deductFromAccount: e.target.checked,
+                        // Clear the source account when the user opts out so
+                        // the DTO does not carry a stale id.
+                        sourceAccountId: e.target.checked
+                          ? prev.sourceAccountId
+                          : '',
+                      }))
+                    }
+                    className="h-5 w-5 rounded border-border/30 bg-card/60 disabled:opacity-50"
+                  />
+                </div>
+                {eligibleSourceAccounts.length === 0 ? (
+                  <p className="text-ios-caption text-muted-foreground">
+                    No tienes otra cuenta en la misma moneda para descontar.
+                  </p>
+                ) : (
+                  formData.deductFromAccount && (
+                    <Select
+                      label="Cuenta de origen"
+                      value={formData.sourceAccountId}
+                      onChange={(e) =>
+                        setFormData({
+                          ...formData,
+                          sourceAccountId: e.target.value,
+                        })
+                      }
+                      options={[
+                        { value: '', label: 'Seleccionar cuenta de origen' },
+                        ...sourceAccountOptions,
+                      ]}
+                      required
+                    />
+                  )
+                )}
 
                 <Select
                   label="Estado"

--- a/hooks/use-transaction-form.ts
+++ b/hooks/use-transaction-form.ts
@@ -347,6 +347,12 @@ export function useTransactionForm(): UseTransactionFormReturn {
         return;
       }
 
+      const shouldDeductDebtFromAccount =
+        canShowDebtFields &&
+        formData.isDebt &&
+        formData.deductFromAccount &&
+        Boolean(formData.sourceAccountId);
+
       const transactionData: CreateTransactionDTO = {
         type: (formData.type as TransactionType) || 'EXPENSE',
         accountId: formData.accountId,
@@ -382,20 +388,16 @@ export function useTransactionForm(): UseTransactionFormReturn {
           formData.debtStatus === DebtStatus.SETTLED
             ? formData.settledAt
             : undefined,
-        // * Debt-only: forward the deduct toggle and the picked source
-        // account so the repository can route to create_debt_with_deduction
-        // (Supabase) or its Dexie-transaction equivalent (local). When the
-        // toggle is off we deliberately omit `sourceAccountId` so the
-        // DTO does not carry a stale value.
+        // * Debt-only: only request the source-account deduction when the
+        // shared/mobile flow actually has a source account. Otherwise the
+        // debt is metadata-only; this prevents mobile debt creation from
+        // failing on the repository's sourceAccountId guard.
         deductFromAccount:
           canShowDebtFields && formData.isDebt
-            ? formData.deductFromAccount
+            ? shouldDeductDebtFromAccount
             : undefined,
         sourceAccountId:
-          canShowDebtFields &&
-          formData.isDebt &&
-          formData.deductFromAccount &&
-          formData.sourceAccountId
+          shouldDeductDebtFromAccount && formData.sourceAccountId
             ? formData.sourceAccountId
             : undefined,
       };

--- a/hooks/use-transaction-form.ts
+++ b/hooks/use-transaction-form.ts
@@ -59,6 +59,11 @@ export interface TransactionFormData {
   debtStatus: DebtStatus;
   counterpartyName: string;
   settledAt: string;
+  // * Debt-only: when true (default), the repository will create a
+  // linked EXPENSE that debits `sourceAccountId` atomically with the
+  // debt row. When false, the debt is metadata only.
+  deductFromAccount: boolean;
+  sourceAccountId: string;
   isRecurring: boolean;
   frequency: 'weekly' | 'monthly' | 'yearly';
   endDate: string;
@@ -79,6 +84,8 @@ const INITIAL_FORM_DATA: TransactionFormData = {
   debtStatus: DebtStatus.OPEN,
   counterpartyName: '',
   settledAt: '',
+  deductFromAccount: true,
+  sourceAccountId: '',
   isRecurring: false,
   frequency: 'monthly',
   endDate: '',
@@ -374,6 +381,22 @@ export function useTransactionForm(): UseTransactionFormReturn {
           formData.isDebt &&
           formData.debtStatus === DebtStatus.SETTLED
             ? formData.settledAt
+            : undefined,
+        // * Debt-only: forward the deduct toggle and the picked source
+        // account so the repository can route to create_debt_with_deduction
+        // (Supabase) or its Dexie-transaction equivalent (local). When the
+        // toggle is off we deliberately omit `sourceAccountId` so the
+        // DTO does not carry a stale value.
+        deductFromAccount:
+          canShowDebtFields && formData.isDebt
+            ? formData.deductFromAccount
+            : undefined,
+        sourceAccountId:
+          canShowDebtFields &&
+          formData.isDebt &&
+          formData.deductFromAccount &&
+          formData.sourceAccountId
+            ? formData.sourceAccountId
             : undefined,
       };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "eslint-config-next": "^16.1.6",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.1.3",
+        "fake-indexeddb": "^5.0.2",
         "fast-check": "^4.4.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
@@ -11458,6 +11459,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-5.0.2.tgz",
+      "integrity": "sha512-cB507r5T3D55DfclY01GLkninZLfU7HXV/mhVRTnTRm5k2u+fY7Fof2dBkr80p5t7G7dlA/G5dI87QiMdPpMCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-check": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "eslint-config-next": "^16.1.6",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.1.3",
+    "fake-indexeddb": "^5.0.2",
     "fast-check": "^4.4.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",

--- a/repositories/local/transactions-repository-impl.ts
+++ b/repositories/local/transactions-repository-impl.ts
@@ -44,6 +44,78 @@ export class LocalTransactionsRepository implements TransactionsRepository {
       ? Math.round(data.amountMinor / exchangeRate)
       : data.amountMinor;
 
+    // Debt + source-account deduction: build the debt and the linked EXPENSE
+    // in a single Dexie transaction so they cannot land in a partial state.
+    if (isDebt && data.deductFromAccount === true) {
+      if (!data.sourceAccountId) {
+        throw new Error(
+          'sourceAccountId is required when deductFromAccount=true'
+        );
+      }
+
+      const debt: Transaction = {
+        id: generateId('txn'),
+        type: data.type,
+        accountId: data.accountId,
+        categoryId: data.categoryId,
+        currencyCode: data.currencyCode,
+        amountMinor: data.amountMinor,
+        amountBaseMinor,
+        exchangeRate,
+        date: data.date,
+        description: data.description,
+        note: data.note,
+        tags: data.tags,
+        isDebt: true,
+        debtDirection: data.debtDirection,
+        debtStatus: data.debtStatus || DebtStatus.OPEN,
+        counterpartyName: data.counterpartyName,
+        settledAt: data.settledAt,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      const expense: Transaction = {
+        id: generateId('txn'),
+        type: TransactionType.EXPENSE,
+        accountId: data.sourceAccountId,
+        categoryId: data.categoryId,
+        currencyCode: data.currencyCode,
+        amountMinor: data.amountMinor,
+        amountBaseMinor,
+        exchangeRate,
+        date: data.date,
+        description: data.description,
+        // Linked EXPENSE always carries the "Debt: <description>" note so
+        // the user can identify the source debt from the EXPENSE row. The
+        // Supabase RPC (`create_debt_with_deduction`) uses the same rule.
+        note: `Debt: ${data.description}`,
+        tags: [
+          'debt-linked',
+          `debt:${debt.id}`,
+          ...((data.tags as string[] | undefined) ?? []),
+        ],
+        isDebt: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      await db.transaction('rw', [db.transactions, db.accounts], async () => {
+        await db.transactions.add(debt);
+        await db.transactions.add(expense);
+        // Debt is metadata: do NOT touch the debt's account balance.
+        // The linked EXPENSE debits the source account via the same
+        // non-debt path used for ordinary expenses.
+        await this.updateAccountBalance(
+          expense.accountId,
+          expense.amountMinor,
+          TransactionType.EXPENSE
+        );
+      });
+
+      return debt;
+    }
+
     const transaction: Transaction = {
       id: generateId('txn'),
       type: data.type,
@@ -68,12 +140,16 @@ export class LocalTransactionsRepository implements TransactionsRepository {
 
     await db.transactions.add(transaction);
 
-    // Update account balance
-    await this.updateAccountBalance(
-      data.accountId,
-      data.amountMinor,
-      data.type
-    );
+    // Update account balance ONLY if the transaction is not a debt.
+    // Debt is metadata and never touches the account balance (parity with
+    // the Supabase RPC skip-guard in 20260706120000_debt_balance_skip.sql).
+    if (!isDebt) {
+      await this.updateAccountBalance(
+        data.accountId,
+        data.amountMinor,
+        data.type
+      );
+    }
 
     return transaction;
   }
@@ -84,12 +160,16 @@ export class LocalTransactionsRepository implements TransactionsRepository {
       throw new Error(`Transaction with id ${id} not found`);
     }
 
-    // Revert old balance change
-    await this.updateAccountBalance(
-      existing.accountId,
-      -existing.amountMinor,
-      existing.type
-    );
+    // Debt transactions never touched the account balance, so we must
+    // not "revert" a balance change that never happened. Same parity rule
+    // as the Supabase RPC skip-guard.
+    if (existing.isDebt !== true) {
+      await this.updateAccountBalance(
+        existing.accountId,
+        -existing.amountMinor,
+        existing.type
+      );
+    }
 
     const nextIsDebt = data.isDebt ?? existing.isDebt ?? false;
     const nextDebtDirection = data.debtDirection ?? existing.debtDirection;
@@ -120,12 +200,15 @@ export class LocalTransactionsRepository implements TransactionsRepository {
 
     await db.transactions.put(updated);
 
-    // Apply new balance change
-    await this.updateAccountBalance(
-      updated.accountId,
-      updated.amountMinor,
-      updated.type
-    );
+    // Apply new balance change ONLY if the row is not a debt (parity with
+    // the Supabase RPC skip-guard).
+    if (nextIsDebt !== true) {
+      await this.updateAccountBalance(
+        updated.accountId,
+        updated.amountMinor,
+        updated.type
+      );
+    }
 
     return updated;
   }
@@ -136,12 +219,15 @@ export class LocalTransactionsRepository implements TransactionsRepository {
       throw new Error(`Transaction with id ${id} not found`);
     }
 
-    // Revert balance change
-    await this.updateAccountBalance(
-      transaction.accountId,
-      -transaction.amountMinor,
-      transaction.type
-    );
+    // Debt rows never touched the account balance, so there is no
+    // balance change to revert (parity with the Supabase RPC skip-guard).
+    if (transaction.isDebt !== true) {
+      await this.updateAccountBalance(
+        transaction.accountId,
+        -transaction.amountMinor,
+        transaction.type
+      );
+    }
 
     await db.transactions.delete(id);
   }

--- a/repositories/supabase/transactions-repository-impl.ts
+++ b/repositories/supabase/transactions-repository-impl.ts
@@ -560,38 +560,41 @@ export class SupabaseTransactionsRepository implements TransactionsRepository {
 
     const updatedTransaction = mapSupabaseTransactionToDomain(data);
 
-    // Update account balance ONLY if the transaction is NOT a debt.
     // Debt rows are metadata: they never touch account balances (see
-    // 20260706120000_debt_balance_skip.sql and design W3).
-    const isDebtAfter =
-      updatedTransaction.isDebt === true || originalTransaction.isDebt === true;
-    if (!isDebtAfter) {
-      try {
-        const originalAdjustment = this.calculateBalanceAdjustment(
-          originalTransaction.type,
-          originalTransaction.amountMinor
-        );
-        const newAdjustment = this.calculateBalanceAdjustment(
-          updatedTransaction.type,
-          updatedTransaction.amountMinor
-        );
-        const balanceDifference = newAdjustment - originalAdjustment;
+    // 20260706120000_debt_balance_skip.sql and design W3). On updates we must
+    // therefore revert only the original non-debt effect and apply only the
+    // updated non-debt effect, so normal↔debt transitions stay correct.
+    try {
+      const originalAdjustment =
+        originalTransaction.isDebt === true
+          ? 0
+          : this.calculateBalanceAdjustment(
+              originalTransaction.type,
+              originalTransaction.amountMinor
+            );
+      const newAdjustment =
+        updatedTransaction.isDebt === true
+          ? 0
+          : this.calculateBalanceAdjustment(
+              updatedTransaction.type,
+              updatedTransaction.amountMinor
+            );
+      const balanceDifference = newAdjustment - originalAdjustment;
 
-        if (balanceDifference !== 0 && this.accountsRepository) {
-          await this.accountsRepository.adjustBalance(
-            updatedTransaction.accountId,
-            balanceDifference
-          );
-          console.log(
-            `✅ Balance updated for account ${updatedTransaction.accountId}: ${balanceDifference > 0 ? '+' : ''}${balanceDifference / 100}`
-          );
-        }
-      } catch (balanceError) {
-        console.error(
-          '❌ Failed to update account balance on transaction update:',
-          balanceError
+      if (balanceDifference !== 0 && this.accountsRepository) {
+        await this.accountsRepository.adjustBalance(
+          updatedTransaction.accountId,
+          balanceDifference
+        );
+        console.log(
+          `✅ Balance updated for account ${updatedTransaction.accountId}: ${balanceDifference > 0 ? '+' : ''}${balanceDifference / 100}`
         );
       }
+    } catch (balanceError) {
+      console.error(
+        '❌ Failed to update account balance on transaction update:',
+        balanceError
+      );
     }
 
     return updatedTransaction;

--- a/repositories/supabase/transactions-repository-impl.ts
+++ b/repositories/supabase/transactions-repository-impl.ts
@@ -317,6 +317,73 @@ export class SupabaseTransactionsRepository implements TransactionsRepository {
       throw new Error('settledAt is required when debtStatus=SETTLED');
     }
 
+    // Debt with source-account deduction: route through the dedicated RPC
+    // that inserts the debt (skip) AND the linked EXPENSE in one transaction.
+    if (transactionData.isDebt === true && transactionData.deductFromAccount) {
+      if (!transactionData.sourceAccountId) {
+        throw new Error(
+          'sourceAccountId is required when deductFromAccount=true'
+        );
+      }
+      const { data, error } = await (this.client as any).rpc(
+        'create_debt_with_deduction',
+        {
+          p_account_id: transactionData.accountId,
+          p_category_id: transactionData.categoryId ?? null,
+          p_type: transactionData.type,
+          p_currency_code: transactionData.currencyCode,
+          p_amount_minor: transactionData.amountMinor,
+          p_amount_base_minor: this.computeAmountBaseMinor(
+            transactionData.amountMinor,
+            transactionData.currencyCode,
+            transactionData.exchangeRate
+          ),
+          p_exchange_rate:
+            transactionData.currencyCode === 'VES'
+              ? transactionData.exchangeRate || 1
+              : 1,
+          p_date: transactionData.date,
+          p_description: transactionData.description,
+          p_note: transactionData.note ?? null,
+          p_tags: transactionData.tags ?? null,
+          p_debt_direction: transactionData.debtDirection,
+          p_debt_status: transactionData.debtStatus ?? DebtStatus.OPEN,
+          p_counterparty_name: transactionData.counterpartyName ?? null,
+          p_settled_at: transactionData.settledAt ?? null,
+          p_deduct: true,
+          p_source_account_id: transactionData.sourceAccountId,
+          // Category for the linked EXPENSE: caller may supply a default
+          // expense category via `categoryId` when it differs from the debt
+          // category. When missing, the RPC falls back to no category.
+          p_source_category_id: transactionData.categoryId ?? null,
+        }
+      );
+
+      if (error) {
+        throw new Error(`Failed to create debt: ${error.message}`);
+      }
+
+      // The RPC returns a json object; we still want the caller to receive
+      // a Transaction domain object representing the debt (not the expense).
+      const debtId =
+        (data && (Array.isArray(data) ? data[0]?.debt_id : data.debt_id)) ??
+        null;
+
+      if (!debtId) {
+        throw new Error('Failed to create debt: missing debt_id in response');
+      }
+
+      const fetched = await this.findById(debtId);
+      if (fetched) {
+        return fetched;
+      }
+      // Fallback: if the lookup misses (cache/RLS edge), surface the
+      // missing-row error so the caller can react instead of receiving
+      // a half-initialized Transaction. (The create_debt_with_deduction
+      // RPC always returns a valid id, so a real miss here is exceptional.)
+      throw new Error(`Failed to load debt row after create (id=${debtId})`);
+    }
+
     const isVesCurrency = transactionData.currencyCode === 'VES';
     const exchangeRate = isVesCurrency ? transactionData.exchangeRate || 1 : 1;
     const amountBaseMinor = isVesCurrency
@@ -385,6 +452,16 @@ export class SupabaseTransactionsRepository implements TransactionsRepository {
 
     const createdTransaction = mapSupabaseTransactionToDomain(data);
     return createdTransaction;
+  }
+
+  private computeAmountBaseMinor(
+    amountMinor: number,
+    currencyCode: string,
+    exchangeRate?: number
+  ): number {
+    if (currencyCode !== 'VES') return amountMinor;
+    const rate = exchangeRate && exchangeRate > 0 ? exchangeRate : 1;
+    return Math.round(amountMinor / rate);
   }
 
   private calculateBalanceAdjustment(
@@ -483,32 +560,38 @@ export class SupabaseTransactionsRepository implements TransactionsRepository {
 
     const updatedTransaction = mapSupabaseTransactionToDomain(data);
 
-    // Update account balance if amount or type changed
-    try {
-      const originalAdjustment = this.calculateBalanceAdjustment(
-        originalTransaction.type,
-        originalTransaction.amountMinor
-      );
-      const newAdjustment = this.calculateBalanceAdjustment(
-        updatedTransaction.type,
-        updatedTransaction.amountMinor
-      );
-      const balanceDifference = newAdjustment - originalAdjustment;
-
-      if (balanceDifference !== 0 && this.accountsRepository) {
-        await this.accountsRepository.adjustBalance(
-          updatedTransaction.accountId,
-          balanceDifference
+    // Update account balance ONLY if the transaction is NOT a debt.
+    // Debt rows are metadata: they never touch account balances (see
+    // 20260706120000_debt_balance_skip.sql and design W3).
+    const isDebtAfter =
+      updatedTransaction.isDebt === true || originalTransaction.isDebt === true;
+    if (!isDebtAfter) {
+      try {
+        const originalAdjustment = this.calculateBalanceAdjustment(
+          originalTransaction.type,
+          originalTransaction.amountMinor
         );
-        console.log(
-          `✅ Balance updated for account ${updatedTransaction.accountId}: ${balanceDifference > 0 ? '+' : ''}${balanceDifference / 100}`
+        const newAdjustment = this.calculateBalanceAdjustment(
+          updatedTransaction.type,
+          updatedTransaction.amountMinor
+        );
+        const balanceDifference = newAdjustment - originalAdjustment;
+
+        if (balanceDifference !== 0 && this.accountsRepository) {
+          await this.accountsRepository.adjustBalance(
+            updatedTransaction.accountId,
+            balanceDifference
+          );
+          console.log(
+            `✅ Balance updated for account ${updatedTransaction.accountId}: ${balanceDifference > 0 ? '+' : ''}${balanceDifference / 100}`
+          );
+        }
+      } catch (balanceError) {
+        console.error(
+          '❌ Failed to update account balance on transaction update:',
+          balanceError
         );
       }
-    } catch (balanceError) {
-      console.error(
-        '❌ Failed to update account balance on transaction update:',
-        balanceError
-      );
     }
 
     return updatedTransaction;

--- a/supabase/migrations/20260706120000_debt_balance_skip.sql
+++ b/supabase/migrations/20260706120000_debt_balance_skip.sql
@@ -37,8 +37,17 @@ CREATE POLICY flags_read
 -- ===========================================================================
 BEGIN;
 
--- Seed the flag first so the new RPC can read it from the start of its
--- first invocation in the same transaction.
+-- Capture the legacy-window cutoff BEFORE the skip guard becomes visible.
+-- `updated_at` stores the transaction timestamp of this pre-commit write,
+-- which the reversal block reuses exactly after COMMIT.
+INSERT INTO public.app_flags (name, enabled, updated_at)
+VALUES ('debt_balance_cutoff', true, transaction_timestamp())
+ON CONFLICT (name) DO UPDATE
+SET enabled = EXCLUDED.enabled,
+    updated_at = LEAST(public.app_flags.updated_at, EXCLUDED.updated_at);
+
+-- Seed the skip flag in the same transaction so the new RPC can read it from
+-- the start of its first invocation once the commit becomes visible.
 INSERT INTO public.app_flags (name, enabled)
 VALUES ('debt_balance_skip_enabled', true)
 ON CONFLICT (name) DO UPDATE SET enabled = EXCLUDED.enabled, updated_at = now();
@@ -159,7 +168,7 @@ COMMIT;
 -- ===========================================================================
 DO $$
 DECLARE
-  v_cutoff timestamptz := clock_timestamp();
+  v_cutoff timestamptz;
   v_reversed_accounts bigint;
 BEGIN
   -- Re-running this DO block after a successful first pass is a no-op
@@ -170,6 +179,16 @@ BEGIN
   ) THEN
     RAISE NOTICE 'debt_balance_skip: reversal already applied, skipping';
     RETURN;
+  END IF;
+
+  SELECT updated_at
+  INTO v_cutoff
+  FROM public.app_flags
+  WHERE name = 'debt_balance_cutoff';
+
+  IF v_cutoff IS NULL THEN
+    RAISE EXCEPTION
+      'debt_balance_skip: missing debt_balance_cutoff flag; refusing reversal to avoid racing post-cutoff debts';
   END IF;
 
   -- Aggregate per-account deltas BEFORE applying them, so we update each

--- a/supabase/migrations/20260706120000_debt_balance_skip.sql
+++ b/supabase/migrations/20260706120000_debt_balance_skip.sql
@@ -1,0 +1,214 @@
+-- Migration: debt_balance_skip
+-- 1. Adds app_flags (lightweight, read-only toggle table).
+-- 2. Flips debt_balance_skip_enabled on AND replaces
+--    create_transaction_and_adjust_balance with a version that honors it
+--    inside a single transaction so the flag cannot be true while the RPC is
+--    still legacy.
+-- 3. Idempotently reverses legacy OPEN-debt balance deltas (guarded by
+--    debt_balance_migrated) using a clock_timestamp cutoff so it never
+--    re-touches a row created after the migration started.
+--
+-- All money is stored as integer minor units.
+
+-- ===========================================================================
+-- 1. app_flags table + RLS (read-only for authenticated, no write policy)
+-- ===========================================================================
+CREATE TABLE IF NOT EXISTS public.app_flags (
+  name text PRIMARY KEY,
+  enabled boolean NOT NULL DEFAULT false,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.app_flags ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS flags_read ON public.app_flags;
+CREATE POLICY flags_read
+  ON public.app_flags
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- No INSERT/UPDATE/DELETE policies on purpose: writes happen only via
+-- service_role SQL (migrations or kill-switch scripts). Clients read the
+-- flag name but cannot toggle it.
+
+-- ===========================================================================
+-- 2. Atomic flag-on + RPC skip guard
+-- ===========================================================================
+BEGIN;
+
+-- Seed the flag first so the new RPC can read it from the start of its
+-- first invocation in the same transaction.
+INSERT INTO public.app_flags (name, enabled)
+VALUES ('debt_balance_skip_enabled', true)
+ON CONFLICT (name) DO UPDATE SET enabled = EXCLUDED.enabled, updated_at = now();
+
+-- Replace the existing RPC (defined in
+-- 20260304120000_add_debt_metadata_to_transactions.sql) with a version
+-- whose balance adjustment respects the flag.
+CREATE OR REPLACE FUNCTION public.create_transaction_and_adjust_balance(
+  p_account_id uuid,
+  p_category_id uuid,
+  p_type text,
+  p_currency_code text,
+  p_amount_minor bigint,
+  p_amount_base_minor bigint,
+  p_exchange_rate numeric,
+  p_date date,
+  p_description text,
+  p_note text DEFAULT NULL,
+  p_tags text[] DEFAULT NULL,
+  p_is_debt boolean DEFAULT false,
+  p_debt_direction public.debt_direction DEFAULT NULL,
+  p_debt_status public.debt_status DEFAULT NULL,
+  p_counterparty_name text DEFAULT NULL,
+  p_settled_at timestamptz DEFAULT NULL
+)
+RETURNS public.transactions
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  created_transaction public.transactions;
+  balance_delta bigint;
+  v_skip_enabled boolean;
+BEGIN
+  IF p_is_debt = true AND p_debt_direction IS NULL THEN
+    RAISE EXCEPTION 'debt_direction is required when is_debt=true';
+  END IF;
+
+  IF p_debt_status = 'SETTLED' AND p_settled_at IS NULL THEN
+    RAISE EXCEPTION 'settled_at is required when debt_status=SETTLED';
+  END IF;
+
+  INSERT INTO public.transactions (
+    account_id,
+    category_id,
+    type,
+    currency_code,
+    amount_minor,
+    amount_base_minor,
+    exchange_rate,
+    date,
+    description,
+    note,
+    tags,
+    is_debt,
+    debt_direction,
+    debt_status,
+    counterparty_name,
+    settled_at
+  )
+  VALUES (
+    p_account_id,
+    p_category_id,
+    p_type,
+    p_currency_code,
+    p_amount_minor,
+    p_amount_base_minor,
+    p_exchange_rate,
+    p_date,
+    p_description,
+    p_note,
+    p_tags,
+    coalesce(p_is_debt, false),
+    p_debt_direction,
+    coalesce(p_debt_status, 'OPEN'),
+    p_counterparty_name,
+    p_settled_at
+  )
+  RETURNING * INTO created_transaction;
+
+  -- Read the flag inside the same transaction; default to false so a
+  -- missing/legacy row preserves the old behavior.
+  SELECT enabled INTO v_skip_enabled
+  FROM public.app_flags
+  WHERE name = 'debt_balance_skip_enabled';
+
+  v_skip_enabled := coalesce(v_skip_enabled, false);
+
+  IF coalesce(p_is_debt, false) AND v_skip_enabled THEN
+    balance_delta := 0; -- debt is metadata, never touches balance
+  ELSE
+    balance_delta := CASE
+      WHEN p_type IN ('INCOME', 'TRANSFER_IN') THEN p_amount_minor
+      ELSE -p_amount_minor
+    END;
+  END IF;
+
+  UPDATE public.accounts
+  SET balance = balance + balance_delta,
+      updated_at = now()
+  WHERE id = p_account_id;
+
+  RETURN created_transaction;
+END;
+$$;
+
+-- p2p_estimator_v2 default ON (design decision W5: default ON, kill via
+-- UPDATE app_flags). Storing the flag here keeps the rollout in a single
+-- transaction with the rest of the foundation.
+INSERT INTO public.app_flags (name, enabled)
+VALUES ('p2p_estimator_v2', true)
+ON CONFLICT (name) DO UPDATE SET enabled = EXCLUDED.enabled, updated_at = now();
+
+COMMIT;
+
+-- ===========================================================================
+-- 3. Idempotent OPEN-debt balance reversal
+-- ===========================================================================
+DO $$
+DECLARE
+  v_cutoff timestamptz := clock_timestamp();
+  v_reversed_accounts bigint;
+BEGIN
+  -- Re-running this DO block after a successful first pass is a no-op
+  -- because debt_balance_migrated is set to true and acts as the guard.
+  IF EXISTS (
+    SELECT 1 FROM public.app_flags
+    WHERE name = 'debt_balance_migrated' AND enabled = true
+  ) THEN
+    RAISE NOTICE 'debt_balance_skip: reversal already applied, skipping';
+    RETURN;
+  END IF;
+
+  -- Aggregate per-account deltas BEFORE applying them, so we update each
+  -- account exactly once with a net reversal. Sign convention:
+  --   legacy INCOME/TRANSFER_IN incremented balance by +amount_minor
+  --   legacy EXPENSE/TRANSFER_OUT decremented balance by -amount_minor
+  -- Reversal: balance -= legacy_delta  (so OPEN-debt deltas are removed)
+  WITH deltas AS (
+    SELECT
+      account_id,
+      SUM(
+        CASE
+          WHEN type IN ('INCOME', 'TRANSFER_IN') THEN amount_minor
+          ELSE -amount_minor
+        END
+      ) AS legacy_delta
+    FROM public.transactions
+    WHERE is_debt = true
+      AND coalesce(debt_status, 'OPEN') = 'OPEN'
+      AND created_at < v_cutoff
+    GROUP BY account_id
+  )
+  UPDATE public.accounts a
+  SET balance = a.balance - d.legacy_delta,
+      updated_at = now()
+  FROM deltas d
+  WHERE a.id = d.account_id;
+
+  GET DIAGNOSTICS v_reversed_accounts = ROW_COUNT;
+
+  INSERT INTO public.app_flags (name, enabled)
+  VALUES
+    ('debt_balance_migrated', true),
+    ('debt_balance_migrated_at', true)
+  ON CONFLICT (name) DO UPDATE SET enabled = EXCLUDED.enabled, updated_at = now();
+
+  RAISE NOTICE 'debt_balance_skip: reversed deltas across % account(s)', v_reversed_accounts;
+END
+$$;
+
+-- Reload PostgREST schema cache so the new RPC and policy are visible.
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260706120100_create_debt_with_deduction_rpc.sql
+++ b/supabase/migrations/20260706120100_create_debt_with_deduction_rpc.sql
@@ -1,0 +1,161 @@
+-- Migration: create_debt_with_deduction RPC
+-- Atomic create of a debt transaction plus, when the user opts in, a linked
+-- EXPENSE that debits a chosen source account. All in one transaction so a
+-- debt can never exist without its linked EXPENSE (or vice versa) on
+-- partial failure.
+--
+-- The debt row goes through the existing create_transaction_and_adjust_balance
+-- RPC so the skip-guard from 20260706120000_debt_balance_skip.sql is reused
+-- (debt is metadata, never touches balance).
+--
+-- The linked EXPENSE is a regular expense that:
+--   * debits the chosen source account (p_source_account_id)
+--   * carries the source's default expense category (p_source_category_id)
+--   * is tagged with `debt-linked` AND `debt:<debt_id>` so the dashboard can
+--     join debt + expense deterministically and exclude it from P2P totals.
+--   * has `note = 'Debt: ' || debt.description` for human-readable audit.
+--
+-- All money is stored as integer minor units.
+--
+-- SECURITY: INVOKER so RLS still applies to every underlying write
+-- (no service_role escalation). Authenticated user must own all referenced
+-- accounts; the RPC raises otherwise.
+
+CREATE OR REPLACE FUNCTION public.create_debt_with_deduction(
+  p_account_id uuid,
+  p_category_id uuid,
+  p_type text,
+  p_currency_code text,
+  p_amount_minor bigint,
+  p_amount_base_minor bigint,
+  p_exchange_rate numeric,
+  p_date date,
+  p_description text,
+  p_note text DEFAULT NULL,
+  p_tags text[] DEFAULT NULL,
+  p_debt_direction public.debt_direction DEFAULT NULL,
+  p_debt_status public.debt_status DEFAULT NULL,
+  p_counterparty_name text DEFAULT NULL,
+  p_settled_at timestamptz DEFAULT NULL,
+  p_deduct boolean DEFAULT false,
+  p_source_account_id uuid DEFAULT NULL,
+  p_source_category_id uuid DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_debt public.transactions;
+  v_expense_id uuid;
+  v_debt_tags text[];
+  v_debt_note text;
+  v_owner uuid;
+BEGIN
+  IF p_deduct THEN
+    IF p_source_account_id IS NULL THEN
+      RAISE EXCEPTION 'source_account_id is required when deduct=true';
+    END IF;
+    IF p_source_category_id IS NULL THEN
+      RAISE EXCEPTION 'source_category_id is required when deduct=true';
+    END IF;
+  END IF;
+
+  IF p_type NOT IN ('INCOME', 'EXPENSE') THEN
+    RAISE EXCEPTION 'debt transactions must be INCOME or EXPENSE';
+  END IF;
+
+  -- Ownership check on the debt account (RLS will also enforce on inserts).
+  SELECT user_id INTO v_owner FROM public.accounts WHERE id = p_account_id;
+  IF v_owner IS NULL OR v_owner <> auth.uid() THEN
+    RAISE EXCEPTION 'Account not found or unauthorized';
+  END IF;
+
+  -- Build a debt-only tags list and a debt-only note so the debt row stays
+  -- a clean "debt is metadata" record. The linked expense will pick up
+  -- the user-provided description via its own note.
+  v_debt_tags := CASE
+    WHEN p_tags IS NULL THEN ARRAY['debt']
+    ELSE array_append(p_tags, 'debt')
+  END;
+
+  v_debt_note := CASE
+    WHEN p_note IS NULL OR length(p_note) = 0 THEN 'Debt: ' || p_description
+    ELSE p_note
+  END;
+
+  -- 1) Insert the debt via the existing RPC so the skip-guard runs.
+  v_debt := public.create_transaction_and_adjust_balance(
+    p_account_id := p_account_id,
+    p_category_id := p_category_id,
+    p_type := p_type,
+    p_currency_code := p_currency_code,
+    p_amount_minor := p_amount_minor,
+    p_amount_base_minor := p_amount_base_minor,
+    p_exchange_rate := p_exchange_rate,
+    p_date := p_date,
+    p_description := p_description,
+    p_note := v_debt_note,
+    p_tags := v_debt_tags,
+    p_is_debt := true,
+    p_debt_direction := p_debt_direction,
+    p_debt_status := coalesce(p_debt_status, 'OPEN'),
+    p_counterparty_name := p_counterparty_name,
+    p_settled_at := p_settled_at
+  );
+
+  v_expense_id := NULL;
+
+  IF p_deduct THEN
+    -- Ownership check on the source account.
+    SELECT user_id INTO v_owner FROM public.accounts WHERE id = p_source_account_id;
+    IF v_owner IS NULL OR v_owner <> auth.uid() THEN
+      RAISE EXCEPTION 'Source account not found or unauthorized';
+    END IF;
+
+    -- 2) Linked EXPENSE: same amount, source account/category, debt-linked
+    -- tags and a human-readable note. Reuse the same RPC so the source
+    -- account's balance is debited via the standard non-debt path.
+    -- NOTE: a nested call would create a savepoint inside the outer
+    -- transaction; on failure the outer transaction still rolls back.
+    WITH inserted AS (
+      SELECT * FROM public.create_transaction_and_adjust_balance(
+        p_account_id := p_source_account_id,
+        p_category_id := p_source_category_id,
+        p_type := 'EXPENSE',
+        p_currency_code := p_currency_code,
+        p_amount_minor := p_amount_minor,
+        p_amount_base_minor := p_amount_base_minor,
+        p_exchange_rate := p_exchange_rate,
+        p_date := p_date,
+        p_description := p_description,
+        p_note := 'Debt: ' || p_description,
+        p_tags := ARRAY['debt-linked', 'debt:' || v_debt.id::text],
+        p_is_debt := false,
+        p_debt_direction := NULL,
+        p_debt_status := NULL,
+        p_counterparty_name := NULL,
+        p_settled_at := NULL
+      )
+    )
+    SELECT id INTO v_expense_id FROM inserted;
+  END IF;
+
+  RETURN json_build_object(
+    'debt_id', v_debt.id,
+    'expense_id', v_expense_id,
+    'debt_deducted', p_deduct
+  );
+END;
+$$;
+
+-- RLS: RPC runs with caller's privileges, so all underlying writes are
+-- governed by the existing RLS policies on transactions and accounts.
+GRANT EXECUTE ON FUNCTION public.create_debt_with_deduction(
+  uuid, uuid, text, text, bigint, bigint, numeric, date,
+  text, text, text[], public.debt_direction, public.debt_status,
+  text, timestamptz, boolean, uuid, uuid
+) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260706120100_create_debt_with_deduction_rpc.sql
+++ b/supabase/migrations/20260706120100_create_debt_with_deduction_rpc.sql
@@ -52,6 +52,9 @@ DECLARE
   v_debt_tags text[];
   v_debt_note text;
   v_owner uuid;
+  v_source_currency_code text;
+  v_category_owner uuid;
+  v_category_is_default boolean;
 BEGIN
   IF p_deduct THEN
     IF p_source_account_id IS NULL THEN
@@ -70,6 +73,21 @@ BEGIN
   SELECT user_id INTO v_owner FROM public.accounts WHERE id = p_account_id;
   IF v_owner IS NULL OR v_owner <> auth.uid() THEN
     RAISE EXCEPTION 'Account not found or unauthorized';
+  END IF;
+
+  IF p_category_id IS NOT NULL THEN
+    SELECT user_id, is_default
+      INTO v_category_owner, v_category_is_default
+    FROM public.categories
+    WHERE id = p_category_id;
+
+    IF v_category_owner IS NULL AND coalesce(v_category_is_default, false) = false THEN
+      RAISE EXCEPTION 'Category not found or unauthorized';
+    END IF;
+
+    IF coalesce(v_category_is_default, false) = false AND v_category_owner <> auth.uid() THEN
+      RAISE EXCEPTION 'Category not found or unauthorized';
+    END IF;
   END IF;
 
   -- Build a debt-only tags list and a debt-only note so the debt row stays
@@ -108,10 +126,30 @@ BEGIN
   v_expense_id := NULL;
 
   IF p_deduct THEN
-    -- Ownership check on the source account.
-    SELECT user_id INTO v_owner FROM public.accounts WHERE id = p_source_account_id;
+    -- Ownership + same-currency check on the source account.
+    SELECT user_id, currency_code
+      INTO v_owner, v_source_currency_code
+    FROM public.accounts
+    WHERE id = p_source_account_id;
     IF v_owner IS NULL OR v_owner <> auth.uid() THEN
       RAISE EXCEPTION 'Source account not found or unauthorized';
+    END IF;
+
+    IF v_source_currency_code IS DISTINCT FROM p_currency_code THEN
+      RAISE EXCEPTION 'Source account currency must match debt currency';
+    END IF;
+
+    SELECT user_id, is_default
+      INTO v_category_owner, v_category_is_default
+    FROM public.categories
+    WHERE id = p_source_category_id;
+
+    IF v_category_owner IS NULL AND coalesce(v_category_is_default, false) = false THEN
+      RAISE EXCEPTION 'Source category not found or unauthorized';
+    END IF;
+
+    IF coalesce(v_category_is_default, false) = false AND v_category_owner <> auth.uid() THEN
+      RAISE EXCEPTION 'Source category not found or unauthorized';
     END IF;
 
     -- 2) Linked EXPENSE: same amount, source account/category, debt-linked

--- a/supabase/migrations/revert_debt_balance_migration.sql
+++ b/supabase/migrations/revert_debt_balance_migration.sql
@@ -1,0 +1,67 @@
+-- Manual rollback for 20260706120000_debt_balance_skip.sql
+-- This file reverses the debt_balance_skip migration by re-applying the
+-- legacy OPEN-debt balance deltas that the original migration removed.
+-- Run only AFTER `debt_balance_skip_enabled` has been flipped to false
+-- (or you accept that new debts created after this revert will be
+-- inconsistent with the flag).
+--
+-- All money is stored as integer minor units.
+
+DO $$
+DECLARE
+  v_cutoff timestamptz := clock_timestamp();
+  v_skip_enabled boolean;
+  v_reapplied_accounts bigint;
+BEGIN
+  -- Guard: refuse to run while the skip flag is on. Re-applying deltas
+  -- while the RPC still ignores them is a recipe for double-reversal.
+  SELECT enabled INTO v_skip_enabled
+  FROM public.app_flags
+  WHERE name = 'debt_balance_skip_enabled';
+
+  IF coalesce(v_skip_enabled, false) THEN
+    RAISE EXCEPTION
+      'revert_debt_balance_migration: debt_balance_skip_enabled is still true. '
+      'Disable the flag first (UPDATE app_flags SET enabled=false WHERE name=''debt_balance_skip_enabled'';).';
+  END IF;
+
+  -- Re-apply the legacy delta so OPEN-debt rows once again touch
+  -- account balances. Sign convention matches the legacy RPC:
+  --   INCOME/TRANSFER_IN -> +amount_minor
+  --   else               -> -amount_minor
+  WITH deltas AS (
+    SELECT
+      account_id,
+      SUM(
+        CASE
+          WHEN type IN ('INCOME', 'TRANSFER_IN') THEN amount_minor
+          ELSE -amount_minor
+        END
+      ) AS legacy_delta
+    FROM public.transactions
+    WHERE is_debt = true
+      AND coalesce(debt_status, 'OPEN') = 'OPEN'
+      AND created_at < v_cutoff
+    GROUP BY account_id
+  )
+  UPDATE public.accounts a
+  SET balance = a.balance + d.legacy_delta,
+      updated_at = now()
+  FROM deltas d
+  WHERE a.id = d.account_id;
+
+  GET DIAGNOSTICS v_reapplied_accounts = ROW_COUNT;
+
+  -- Mark the migration as no longer applied so a re-run of the original
+  -- forward migration would reverse again.
+  UPDATE public.app_flags
+  SET enabled = false, updated_at = now()
+  WHERE name = 'debt_balance_migrated';
+
+  RAISE NOTICE
+    'revert_debt_balance_migration: re-applied deltas across % account(s)',
+    v_reapplied_accounts;
+END
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/dom/components/forms/transaction-form-debt-deduction.test.tsx
+++ b/tests/dom/components/forms/transaction-form-debt-deduction.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Smoke tests for the debt-only UI additions in TransactionForm:
+ *   - "Descontar de cuenta" toggle
+ *   - Currency-filtered source-account picker
+ *   - Disabled state when no eligible account exists
+ */
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { TransactionForm } from '@/components/forms/transaction-form';
+import { DebtDirection, DebtStatus, TransactionType } from '@/types';
+import type { Account, Category } from '@/types/domain';
+
+// Mock heavy dependencies so the component only renders its UI.
+// IMPORTANT: mocks must return STABLE references; otherwise the form's
+// useEffect on `[isOpen, user, repository]` will re-run on every render
+// and trip React's "Maximum update depth" guard.
+jest.mock('@/providers', () => {
+  const repo = {
+    accounts: { findByUserId: jest.fn().mockResolvedValue([]) },
+    categories: { findAll: jest.fn().mockResolvedValue([]) },
+    transactions: {
+      create: jest.fn().mockResolvedValue({ id: 'tx-1' }),
+      update: jest.fn(),
+    },
+  };
+  return {
+    useRepository: () => repo,
+    __repo: repo,
+  };
+});
+
+const authState = { user: { id: 'user-1' } };
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: () => authState,
+}));
+
+const subState = {
+  usageStatus: { transactions: { used: 0, limit: 100 } },
+  isAtLimit: () => false,
+  tier: 'free',
+};
+jest.mock('@/hooks/use-subscription', () => ({
+  useSubscription: () => subState,
+}));
+
+jest.mock('@/hooks', () => ({
+  useModal: () => ({
+    isOpen: false,
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+  }),
+}));
+
+jest.mock('@/components/subscription/upgrade-modal', () => ({
+  UpgradeModal: () => null,
+}));
+
+jest.mock('@/components/forms/category-form', () => ({
+  CategoryForm: () => null,
+}));
+
+jest.mock('@/lib/rates', () => ({
+  useActiveUsdVesRate: () => 36.5,
+}));
+
+jest.mock('@/lib/utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn() },
+}));
+
+const pushToast = jest.fn();
+jest.mock('sonner', () => ({
+  toast: {
+    success: (...args: any[]) => pushToast('success', ...args),
+    error: (...args: any[]) => pushToast('error', ...args),
+  },
+}));
+
+const accounts: Account[] = [
+  {
+    id: 'cash-usd',
+    name: 'Cash USD',
+    type: 'CASH' as any,
+    currencyCode: 'USD',
+    balance: 100000,
+    active: true,
+    createdAt: '2026-07-06T00:00:00Z',
+    updatedAt: '2026-07-06T00:00:00Z',
+  },
+  {
+    id: 'savings-usd',
+    name: 'Savings USD',
+    type: 'SAVINGS' as any,
+    currencyCode: 'USD',
+    balance: 50000,
+    active: true,
+    createdAt: '2026-07-06T00:00:00Z',
+    updatedAt: '2026-07-06T00:00:00Z',
+  },
+  {
+    id: 'cash-ves',
+    name: 'Cash VES',
+    type: 'CASH' as any,
+    currencyCode: 'VES',
+    balance: 0,
+    active: true,
+    createdAt: '2026-07-06T00:00:00Z',
+    updatedAt: '2026-07-06T00:00:00Z',
+  },
+];
+
+const categories: Category[] = [
+  {
+    id: 'cat-1',
+    name: 'General',
+    kind: 'EXPENSE' as any,
+    color: '#000',
+    icon: 'tag',
+    active: true,
+    userId: 'user-1',
+    isDefault: true,
+    createdAt: '2026-07-06T00:00:00Z',
+    updatedAt: '2026-07-06T00:00:00Z',
+  },
+];
+
+// `require` here (not import) so the test module can re-use the repo
+// mock the jest.mock factory installed at the top of the file.
+const repositoryMock = require('@/providers').__repo;
+repositoryMock.accounts.findByUserId.mockResolvedValue(accounts);
+repositoryMock.categories.findAll.mockResolvedValue(categories);
+
+const createMock = repositoryMock.transactions.create;
+
+describe('TransactionForm debt deduction UI', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+    createMock.mockResolvedValue({ id: 'tx-1' });
+    pushToast.mockReset();
+  });
+
+  it('shows the deduct toggle and source picker when a debt is created', async () => {
+    render(
+      <TransactionForm
+        isOpen
+        onClose={jest.fn()}
+        debtMode="create"
+        type={TransactionType.EXPENSE}
+      />
+    );
+
+    // Debug: dump the DOM if the toggle is not found.
+    await waitFor(
+      () => {
+        expect(
+          screen.getByLabelText('Descontar de cuenta')
+        ).toBeInTheDocument();
+      },
+      { timeout: 2000 }
+    ).catch(() => {
+      // eslint-disable-next-line no-console
+      console.log('FORM DOM:\n', document.body.innerHTML);
+      throw new Error('toggle not found');
+    });
+  });
+
+  it('disables the deduct toggle when no eligible account in the chosen currency exists', async () => {
+    render(
+      <TransactionForm
+        isOpen
+        onClose={jest.fn()}
+        debtMode="create"
+        type={TransactionType.EXPENSE}
+      />
+    );
+
+    // Wait for the deduct toggle to appear (proves data loaded).
+    await waitFor(() => {
+      expect(screen.getByLabelText('Descontar de cuenta')).toBeInTheDocument();
+    });
+
+    // Pick the VES account so the picker has no USD peer.
+    const accountSelect = screen.getByLabelText('Cuenta') as HTMLSelectElement;
+    fireEvent.change(accountSelect, { target: { value: 'cash-ves' } });
+
+    await waitFor(() => {
+      const toggle = screen.getByLabelText(
+        'Descontar de cuenta'
+      ) as HTMLInputElement;
+      expect(toggle.disabled).toBe(true);
+    });
+    expect(
+      screen.getByText(/No tienes otra cuenta en la misma moneda/i)
+    ).toBeInTheDocument();
+  });
+
+  it('hides the source picker when the user un-toggles deduct', async () => {
+    render(
+      <TransactionForm
+        isOpen
+        onClose={jest.fn()}
+        debtMode="create"
+        type={TransactionType.EXPENSE}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Descontar de cuenta')).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByLabelText(
+      'Descontar de cuenta'
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toggle.checked).toBe(false);
+    });
+    // Picker should disappear once the toggle is off.
+    expect(screen.queryByLabelText('Cuenta de origen')).not.toBeInTheDocument();
+  });
+
+  it('forwards deductFromAccount and sourceAccountId to the repository on submit', async () => {
+    const { container } = render(
+      <TransactionForm
+        isOpen
+        onClose={jest.fn()}
+        debtMode="create"
+        type={TransactionType.EXPENSE}
+      />
+    );
+
+    // Wait for the form to be ready.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Descontar de cuenta')).toBeInTheDocument();
+    });
+
+    // The category <select> is not linked to its label via `htmlFor`, so we
+    // find it by selecting the only <select> whose first option label is
+    // "Seleccionar categoría" (the placeholder text).
+    const selects = Array.from(
+      container.querySelectorAll('select')
+    ) as HTMLSelectElement[];
+    const categorySelect = selects.find((s) =>
+      Array.from(s.options).some(
+        (o) => o.textContent === 'Seleccionar categoría'
+      )
+    );
+    expect(categorySelect).toBeDefined();
+
+    // Fill the required fields.
+    fireEvent.change(screen.getByLabelText('Monto'), {
+      target: { value: '50' },
+    });
+    fireEvent.change(screen.getByLabelText('Cuenta'), {
+      target: { value: 'cash-usd' },
+    });
+    fireEvent.change(categorySelect!, { target: { value: 'cat-1' } });
+    fireEvent.change(screen.getByLabelText('Descripción'), {
+      target: { value: 'Borrowed 50' },
+    });
+    fireEvent.change(screen.getByLabelText('Direccion'), {
+      target: { value: DebtDirection.OWE },
+    });
+    // Pick the other USD account as the source.
+    fireEvent.change(screen.getByLabelText('Cuenta de origen'), {
+      target: { value: 'savings-usd' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/i }));
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDebt: true,
+        debtDirection: DebtDirection.OWE,
+        deductFromAccount: true,
+        sourceAccountId: 'savings-usd',
+      })
+    );
+  });
+});

--- a/tests/dom/components/forms/transaction-form-debt-deduction.test.tsx
+++ b/tests/dom/components/forms/transaction-form-debt-deduction.test.tsx
@@ -147,18 +147,8 @@ describe('TransactionForm debt deduction UI', () => {
       />
     );
 
-    // Debug: dump the DOM if the toggle is not found.
-    await waitFor(
-      () => {
-        expect(
-          screen.getByLabelText('Descontar de cuenta')
-        ).toBeInTheDocument();
-      },
-      { timeout: 2000 }
-    ).catch(() => {
-      // eslint-disable-next-line no-console
-      console.log('FORM DOM:\n', document.body.innerHTML);
-      throw new Error('toggle not found');
+    await waitFor(() => {
+      expect(screen.getByLabelText('Descontar de cuenta')).toBeInTheDocument();
     });
   });
 
@@ -190,6 +180,62 @@ describe('TransactionForm debt deduction UI', () => {
     expect(
       screen.getByText(/No tienes otra cuenta en la misma moneda/i)
     ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Descontar de cuenta') as HTMLInputElement
+    ).not.toBeChecked();
+  });
+
+  it('submits debt metadata-only when no eligible source account exists', async () => {
+    const { container } = render(
+      <TransactionForm
+        isOpen
+        onClose={jest.fn()}
+        debtMode="create"
+        type={TransactionType.EXPENSE}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Descontar de cuenta')).toBeInTheDocument();
+    });
+
+    const selects = Array.from(
+      container.querySelectorAll('select')
+    ) as HTMLSelectElement[];
+    const categorySelect = selects.find((s) =>
+      Array.from(s.options).some(
+        (o) => o.textContent === 'Seleccionar categoría'
+      )
+    );
+    expect(categorySelect).toBeDefined();
+
+    fireEvent.change(screen.getByLabelText('Monto'), {
+      target: { value: '20' },
+    });
+    fireEvent.change(screen.getByLabelText('Cuenta'), {
+      target: { value: 'cash-ves' },
+    });
+    fireEvent.change(categorySelect!, { target: { value: 'cat-1' } });
+    fireEvent.change(screen.getByLabelText('Descripción'), {
+      target: { value: 'Debt without source account' },
+    });
+    fireEvent.change(screen.getByLabelText('Direccion'), {
+      target: { value: DebtDirection.OWE },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/i }));
+
+    await waitFor(() => {
+      expect(createMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDebt: true,
+        deductFromAccount: false,
+      })
+    );
+    expect(createMock.mock.calls[0][0].sourceAccountId).toBeUndefined();
   });
 
   it('hides the source picker when the user un-toggles deduct', async () => {
@@ -204,6 +250,10 @@ describe('TransactionForm debt deduction UI', () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText('Descontar de cuenta')).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText('Cuenta'), {
+      target: { value: 'cash-usd' },
     });
 
     const toggle = screen.getByLabelText(

--- a/tests/node/repositories/create-debt-with-deduction-rpc-migration.test.ts
+++ b/tests/node/repositories/create-debt-with-deduction-rpc-migration.test.ts
@@ -58,4 +58,27 @@ describe('create_debt_with_deduction RPC migration', () => {
     expect(migration).toMatch(/debt_id/i);
     expect(migration).toMatch(/expense_id/i);
   });
+
+  it('validates source account currency matches the debt currency', () => {
+    const migration = readMigration();
+    expect(migration).toMatch(
+      /SELECT user_id, currency_code\s+INTO v_owner, v_source_currency_code/i
+    );
+    expect(migration).toMatch(
+      /v_source_currency_code\s+IS DISTINCT FROM\s+p_currency_code/i
+    );
+    expect(migration).toMatch(
+      /Source account currency must match debt currency/i
+    );
+  });
+
+  it('validates debt and source category ownership on the server', () => {
+    const migration = readMigration();
+    expect(migration).toMatch(/WHERE id = p_category_id/i);
+    expect(migration).toMatch(/Category not found or unauthorized/i);
+    expect(migration).toMatch(/WHERE id = p_source_category_id/i);
+    expect(migration).toMatch(/Source category not found or unauthorized/i);
+    expect(migration).toMatch(/is_default/i);
+    expect(migration).toMatch(/auth\.uid\(\)/i);
+  });
 });

--- a/tests/node/repositories/create-debt-with-deduction-rpc-migration.test.ts
+++ b/tests/node/repositories/create-debt-with-deduction-rpc-migration.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const RPC_MIGRATION_PATH = join(
+  process.cwd(),
+  'supabase/migrations/20260706120100_create_debt_with_deduction_rpc.sql'
+);
+
+function readMigration(): string {
+  return readFileSync(RPC_MIGRATION_PATH, 'utf8');
+}
+
+describe('create_debt_with_deduction RPC migration', () => {
+  it('exists at the canonical path', () => {
+    expect(existsSync(RPC_MIGRATION_PATH)).toBe(true);
+  });
+
+  it('declares create_debt_with_deduction as SECURITY INVOKER', () => {
+    const migration = readMigration();
+    expect(migration).toMatch(
+      /CREATE OR REPLACE FUNCTION public\.create_debt_with_deduction/i
+    );
+    expect(migration).toMatch(/SECURITY INVOKER/i);
+  });
+
+  it('accepts the debt payload, deduct toggle, and source account parameters', () => {
+    const migration = readMigration();
+    // p_deduct is a boolean toggle and p_source_account_id is a uuid;
+    // the source category id is needed for the linked EXPENSE.
+    expect(migration).toMatch(/p_deduct\s+boolean/i);
+    expect(migration).toMatch(/p_source_account_id\s+uuid/i);
+    expect(migration).toMatch(/p_source_category_id\s+uuid/i);
+  });
+
+  it('inserts the debt honoring the skip flag inside one transaction', () => {
+    const migration = readMigration();
+    // The RPC must call the existing create_transaction_and_adjust_balance
+    // (or equivalent) so the skip guard is reused — no duplicated logic.
+    expect(migration).toMatch(/create_transaction_and_adjust_balance/i);
+  });
+
+  it('only creates the linked EXPENSE when p_deduct is true', () => {
+    const migration = readMigration();
+    expect(migration).toMatch(/IF\s+p_deduct\s+THEN/i);
+  });
+
+  it('tags the linked EXPENSE so it can be traced back to the debt', () => {
+    const migration = readMigration();
+    // tags must include a debt-linked marker AND a back-reference to the
+    // debt id so the dashboard / reports can join them deterministically.
+    expect(migration).toMatch(/'debt-linked'/i);
+    expect(migration).toMatch(/'debt:'/i);
+  });
+
+  it('returns both debt and linked expense identifiers', () => {
+    const migration = readMigration();
+    // Return shape: json with debt_id and (when deducted) expense_id.
+    expect(migration).toMatch(/debt_id/i);
+    expect(migration).toMatch(/expense_id/i);
+  });
+});

--- a/tests/node/repositories/debt-balance-skip-migration.test.ts
+++ b/tests/node/repositories/debt-balance-skip-migration.test.ts
@@ -60,7 +60,13 @@ describe('debt balance skip migration', () => {
       // transaction so the flag cannot be true while the RPC is still legacy.
       expect(migration).toMatch(/BEGIN\s*;/i);
       expect(migration).toMatch(
+        /INSERT INTO public\.app_flags \(name, enabled, updated_at\)\s+VALUES \('debt_balance_cutoff',\s*true,\s*transaction_timestamp\(\)\)/i
+      );
+      expect(migration).toMatch(
         /INSERT INTO public\.app_flags\s+\(name,\s*enabled\)\s+VALUES\s*\('debt_balance_skip_enabled',\s*true\)/i
+      );
+      expect(migration).toMatch(
+        /debt_balance_cutoff[\s\S]*debt_balance_skip_enabled[\s\S]*CREATE OR REPLACE FUNCTION public\.create_transaction_and_adjust_balance/i
       );
       expect(migration).toMatch(
         /CREATE OR REPLACE FUNCTION public\.create_transaction_and_adjust_balance/i
@@ -101,13 +107,14 @@ describe('debt balance skip migration', () => {
       );
     });
 
-    it('captures a clock_timestamp cutoff before computing deltas', () => {
+    it('reuses the stored pre-commit cutoff before computing deltas', () => {
       const migration = readMigration();
-      // DECLARE block declares the type explicitly: `v_cutoff timestamptz := clock_timestamp();`
       expect(migration).toMatch(
-        /v_cutoff\s+(?:timestamptz\s+)?:=\s*clock_timestamp\(\)/i
+        /SELECT updated_at\s+INTO v_cutoff\s+FROM public\.app_flags\s+WHERE name = 'debt_balance_cutoff'/i
       );
+      expect(migration).toMatch(/IF v_cutoff IS NULL THEN/i);
       expect(migration).toMatch(/created_at\s*<\s*v_cutoff/i);
+      expect(migration).not.toMatch(/created_at\s*<\s*clock_timestamp\(\)/i);
     });
 
     it('reverses only OPEN debts and uses the direction sign convention', () => {

--- a/tests/node/repositories/debt-balance-skip-migration.test.ts
+++ b/tests/node/repositories/debt-balance-skip-migration.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const MIGRATION_PATH = join(
+  process.cwd(),
+  'supabase/migrations/20260706120000_debt_balance_skip.sql'
+);
+const REVERT_PATH = join(
+  process.cwd(),
+  'supabase/migrations/revert_debt_balance_migration.sql'
+);
+
+function readMigration(): string {
+  return readFileSync(MIGRATION_PATH, 'utf8');
+}
+
+function readRevert(): string {
+  return readFileSync(REVERT_PATH, 'utf8');
+}
+
+describe('debt balance skip migration', () => {
+  it('exists at the canonical path', () => {
+    expect(existsSync(MIGRATION_PATH)).toBe(true);
+  });
+
+  describe('app_flags table', () => {
+    it('creates app_flags with name primary key and enabled boolean', () => {
+      const migration = readMigration();
+      expect(migration).toMatch(
+        /CREATE TABLE(?:\s+IF NOT EXISTS)?\s+public\.app_flags/i
+      );
+      expect(migration).toMatch(/name\s+text\s+PRIMARY KEY/i);
+      expect(migration).toMatch(
+        /enabled\s+boolean\s+NOT NULL\s+DEFAULT\s+false/i
+      );
+    });
+
+    it('enables row level security on app_flags', () => {
+      const migration = readMigration();
+      expect(migration).toContain(
+        'ALTER TABLE public.app_flags ENABLE ROW LEVEL SECURITY'
+      );
+    });
+
+    it('exposes a read-only policy for authenticated users and no write policy', () => {
+      const migration = readMigration();
+      expect(migration).toMatch(
+        /CREATE POLICY\s+flags_read\s+ON\s+public\.app_flags[\s\S]*?FOR SELECT\s+TO authenticated/i
+      );
+      expect(migration).not.toMatch(
+        /CREATE POLICY[\s\S]*?ON\s+public\.app_flags[\s\S]*?FOR (INSERT|UPDATE|DELETE)/i
+      );
+    });
+  });
+
+  describe('atomic flag-on + RPC skip guard', () => {
+    it('seeds the debt_balance_skip_enabled flag inside a single transaction', () => {
+      const migration = readMigration();
+      // Must wrap the flag INSERT and the CREATE OR REPLACE inside a single
+      // transaction so the flag cannot be true while the RPC is still legacy.
+      expect(migration).toMatch(/BEGIN\s*;/i);
+      expect(migration).toMatch(
+        /INSERT INTO public\.app_flags\s+\(name,\s*enabled\)\s+VALUES\s*\('debt_balance_skip_enabled',\s*true\)/i
+      );
+      expect(migration).toMatch(
+        /CREATE OR REPLACE FUNCTION public\.create_transaction_and_adjust_balance/i
+      );
+      expect(migration).toMatch(/COMMIT\s*;/i);
+    });
+
+    it('rewrites the existing RPC with a skip guard that honors the flag', () => {
+      const migration = readMigration();
+      expect(migration).toMatch(
+        /CREATE OR REPLACE FUNCTION public\.create_transaction_and_adjust_balance[\s\S]*?p_is_debt boolean/i
+      );
+      // The skip guard must zero out the balance delta when is_debt is true AND
+      // the app flag is on. The current implementation reads the flag into a
+      // local variable first, so we accept either form (inline subquery or
+      // local variable).
+      expect(migration).toMatch(/balance_delta := 0/);
+      expect(migration).toMatch(
+        /coalesce\(p_is_debt,\s*false\)\s+AND\s+(?:v_skip_enabled|coalesce\(\s*\(\s*SELECT\s+enabled\s+FROM\s+public\.app_flags)/i
+      );
+    });
+
+    it('still applies the legacy delta when the flag is off', () => {
+      const migration = readMigration();
+      expect(migration).toMatch(
+        /balance_delta := CASE[\s\S]*?p_type IN \('INCOME', 'TRANSFER_IN'\)[\s\S]*?ELSE -p_amount_minor\s+END/i
+      );
+    });
+  });
+
+  describe('idempotent OPEN-debt balance reversal', () => {
+    it('guards the reversal with a debt_balance_migrated flag', () => {
+      const migration = readMigration();
+      // The guard can be expressed as either a single INSERT with two rows
+      // or two separate inserts; both forms set debt_balance_migrated=true.
+      expect(migration).toMatch(
+        /INSERT INTO public\.app_flags\s+\(name,\s*enabled\)[\s\S]*?'debt_balance_migrated',\s*true/i
+      );
+    });
+
+    it('captures a clock_timestamp cutoff before computing deltas', () => {
+      const migration = readMigration();
+      // DECLARE block declares the type explicitly: `v_cutoff timestamptz := clock_timestamp();`
+      expect(migration).toMatch(
+        /v_cutoff\s+(?:timestamptz\s+)?:=\s*clock_timestamp\(\)/i
+      );
+      expect(migration).toMatch(/created_at\s*<\s*v_cutoff/i);
+    });
+
+    it('reverses only OPEN debts and uses the direction sign convention', () => {
+      const migration = readMigration();
+      expect(migration).toMatch(/WHERE is_debt = true/i);
+      expect(migration).toMatch(
+        /coalesce\(debt_status,\s*'OPEN'\)\s*=\s*'OPEN'/i
+      );
+      // OWE behaves like EXPENSE (legacy -amount, reversal +amount);
+      // OWED_TO_ME behaves like INCOME (legacy +amount, reversal -amount).
+      // The DO block reads the column directly so it should reference
+      // `type`, not `p_type` (which is the RPC parameter).
+      expect(migration).toMatch(
+        /WHEN type IN \('INCOME', 'TRANSFER_IN'\) THEN amount_minor\s+ELSE -amount_minor\s+END/i
+      );
+    });
+  });
+});
+
+describe('revert_debt_balance_migration', () => {
+  it('exists at the canonical path', () => {
+    expect(existsSync(REVERT_PATH)).toBe(true);
+  });
+
+  it('re-applies legacy OPEN-debt deltas to balances', () => {
+    const revert = readRevert();
+    expect(revert).toMatch(/reverses? (the )?debt_balance_skip migration/i);
+    expect(revert).toMatch(
+      /WHEN type IN \('INCOME', 'TRANSFER_IN'\) THEN amount_minor\s+ELSE -amount_minor\s+END/i
+    );
+    expect(revert).toMatch(/WHERE is_debt = true/i);
+    expect(revert).toMatch(/coalesce\(debt_status,\s*'OPEN'\)\s*=\s*'OPEN'/i);
+  });
+
+  it('guards itself so it cannot run while the skip flag is enabled', () => {
+    const revert = readRevert();
+    // It must refuse to run when debt_balance_skip_enabled is true.
+    expect(revert).toMatch(/debt_balance_skip_enabled/i);
+  });
+});

--- a/tests/node/repositories/local-transactions-debt-parity.test.ts
+++ b/tests/node/repositories/local-transactions-debt-parity.test.ts
@@ -1,0 +1,164 @@
+// Polyfill IndexedDB for the node test env so Dexie can run.
+import 'fake-indexeddb/auto';
+
+import { DebtDirection, DebtStatus } from '@/types';
+import { LocalTransactionsRepository } from '@/repositories/local/transactions-repository-impl';
+import { db } from '@/repositories/local/db';
+
+/**
+ * Local parity tests for the debt + deduct behavior.
+ *
+ * These tests use the real Dexie database instance in a fake-indexeddb-like
+ * environment. The jsdom test env provides `indexedDB` so we can let Dexie
+ * run against a real (in-memory) store.
+ */
+describe('LocalTransactionsRepository debt parity', () => {
+  let repo: LocalTransactionsRepository;
+  const userId = 'user-1';
+
+  beforeEach(async () => {
+    // Reset Dexie between tests.
+    if (db.isOpen()) {
+      await db.delete();
+    }
+    await db.open();
+    await db.accounts.clear();
+    await db.transactions.clear();
+    await db.accounts.add({
+      id: 'cash',
+      userId,
+      name: 'Cash',
+      type: 'CASH' as any,
+      currencyCode: 'USD',
+      balance: 100000,
+      active: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    await db.accounts.add({
+      id: 'savings',
+      userId,
+      name: 'Savings',
+      type: 'SAVINGS' as any,
+      currencyCode: 'USD',
+      balance: 50000,
+      active: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    repo = new LocalTransactionsRepository();
+  });
+
+  afterAll(async () => {
+    if (db.isOpen()) {
+      await db.delete();
+    }
+  });
+
+  it('does NOT touch account balance when creating a debt-only transaction', async () => {
+    await repo.create({
+      type: 'EXPENSE' as any,
+      accountId: 'cash',
+      currencyCode: 'USD',
+      amountMinor: 25000,
+      date: '2026-07-06',
+      description: 'Lent 250 USD to bob',
+      isDebt: true,
+      debtDirection: DebtDirection.OWED_TO_ME,
+      debtStatus: DebtStatus.OPEN,
+      deductFromAccount: false,
+    } as any);
+
+    const account = await db.accounts.get('cash');
+    expect(account?.balance).toBe(100000);
+  });
+
+  it('debits the source account when deductFromAccount is true', async () => {
+    const result = await repo.create({
+      type: 'EXPENSE' as any,
+      accountId: 'cash',
+      currencyCode: 'USD',
+      amountMinor: 25000,
+      date: '2026-07-06',
+      description: 'Lent 250 USD to bob',
+      isDebt: true,
+      debtDirection: DebtDirection.OWED_TO_ME,
+      debtStatus: DebtStatus.OPEN,
+      deductFromAccount: true,
+      sourceAccountId: 'savings',
+    } as any);
+
+    // Savings was debited by 250 USD (25000 minor).
+    const savings = await db.accounts.get('savings');
+    expect(savings?.balance).toBe(50000 - 25000);
+
+    // Cash was NOT touched by the debt (debt never touches balance).
+    const cash = await db.accounts.get('cash');
+    expect(cash?.balance).toBe(100000);
+
+    // Two transactions were created: the debt (skip) and the linked EXPENSE.
+    const all = await db.transactions.toArray();
+    expect(all).toHaveLength(2);
+    const debtRow = all.find((t) => t.isDebt);
+    const expenseRow = all.find((t) => !t.isDebt);
+    expect(debtRow).toBeDefined();
+    expect(expenseRow).toBeDefined();
+    expect(expenseRow?.accountId).toBe('savings');
+    expect(expenseRow?.type).toBe('EXPENSE');
+    expect(result.id).toBe(debtRow?.id);
+  });
+
+  it('skips balance adjustment on update for a debt transaction', async () => {
+    const created = await repo.create({
+      type: 'EXPENSE' as any,
+      accountId: 'cash',
+      currencyCode: 'USD',
+      amountMinor: 10000,
+      date: '2026-07-06',
+      description: 'Test debt',
+      isDebt: true,
+      debtDirection: DebtDirection.OWE,
+      debtStatus: DebtStatus.OPEN,
+      deductFromAccount: false,
+    } as any);
+
+    const before = (await db.accounts.get('cash'))?.balance;
+
+    // Update the debt — amount and direction change, but balance must NOT
+    // move (debt is metadata).
+    await repo.update(created.id, {
+      type: 'EXPENSE' as any,
+      accountId: 'cash',
+      currencyCode: 'USD',
+      amountMinor: 20000,
+      date: '2026-07-06',
+      description: 'Updated debt',
+      isDebt: true,
+      debtDirection: DebtDirection.OWE,
+      debtStatus: DebtStatus.OPEN,
+    } as any);
+
+    const after = (await db.accounts.get('cash'))?.balance;
+    expect(after).toBe(before);
+  });
+
+  it('skips balance adjustment on delete for a debt transaction', async () => {
+    const created = await repo.create({
+      type: 'EXPENSE' as any,
+      accountId: 'cash',
+      currencyCode: 'USD',
+      amountMinor: 10000,
+      date: '2026-07-06',
+      description: 'Test debt',
+      isDebt: true,
+      debtDirection: DebtDirection.OWE,
+      debtStatus: DebtStatus.OPEN,
+      deductFromAccount: false,
+    } as any);
+
+    const before = (await db.accounts.get('cash'))?.balance;
+    await repo.delete(created.id);
+    const after = (await db.accounts.get('cash'))?.balance;
+    expect(after).toBe(before);
+  });
+});

--- a/tests/node/repositories/transactions-debt-parity.test.ts
+++ b/tests/node/repositories/transactions-debt-parity.test.ts
@@ -389,4 +389,110 @@ describe('debt with deduction (Supabase repo)', () => {
       expect.objectContaining({ transaction_id_input: 'd-1' })
     );
   });
+
+  it('reverts the original balance effect when updating a normal transaction into debt', async () => {
+    const client = buildSupabaseRpcMock();
+    const updateChain: any = {
+      update: jest.fn(() => updateChain),
+      eq: jest.fn(() => updateChain),
+      select: jest.fn(() => updateChain),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'tx-1',
+          type: 'EXPENSE',
+          account_id: 'acc-1',
+          amount_minor: 5000,
+          amount_base_minor: 5000,
+          currency_code: 'USD',
+          date: '2026-07-06',
+          is_debt: true,
+          debt_direction: DebtDirection.OWE,
+          debt_status: DebtStatus.OPEN,
+          created_at: '2026-07-06T00:00:00Z',
+          updated_at: '2026-07-06T00:00:00Z',
+        },
+        error: null,
+      }),
+    };
+    client.from = jest.fn(() => updateChain) as any;
+
+    const repo = new SupabaseTransactionsRepository(client as any);
+    const adjustBalance = jest.fn().mockResolvedValue(undefined);
+    repo.setAccountsRepository({ adjustBalance } as any);
+    jest.spyOn(repo, 'findById').mockResolvedValue({
+      id: 'tx-1',
+      type: 'EXPENSE' as any,
+      accountId: 'acc-1',
+      categoryId: null,
+      currencyCode: 'USD',
+      amountMinor: 5000,
+      amountBaseMinor: 5000,
+      exchangeRate: 1,
+      date: '2026-07-06',
+      isDebt: false,
+      createdAt: '2026-07-06T00:00:00Z',
+      updatedAt: '2026-07-06T00:00:00Z',
+    } as any);
+
+    await repo.update('tx-1', {
+      isDebt: true,
+      debtDirection: DebtDirection.OWE,
+    } as any);
+
+    expect(adjustBalance).toHaveBeenCalledWith('acc-1', 5000);
+  });
+
+  it('applies the new balance effect when updating a debt transaction into normal', async () => {
+    const client = buildSupabaseRpcMock();
+    const updateChain: any = {
+      update: jest.fn(() => updateChain),
+      eq: jest.fn(() => updateChain),
+      select: jest.fn(() => updateChain),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'tx-2',
+          type: 'INCOME',
+          account_id: 'acc-1',
+          amount_minor: 7000,
+          amount_base_minor: 7000,
+          currency_code: 'USD',
+          date: '2026-07-06',
+          is_debt: false,
+          debt_direction: null,
+          debt_status: null,
+          created_at: '2026-07-06T00:00:00Z',
+          updated_at: '2026-07-06T00:00:00Z',
+        },
+        error: null,
+      }),
+    };
+    client.from = jest.fn(() => updateChain) as any;
+
+    const repo = new SupabaseTransactionsRepository(client as any);
+    const adjustBalance = jest.fn().mockResolvedValue(undefined);
+    repo.setAccountsRepository({ adjustBalance } as any);
+    jest.spyOn(repo, 'findById').mockResolvedValue({
+      id: 'tx-2',
+      type: 'INCOME' as any,
+      accountId: 'acc-1',
+      categoryId: null,
+      currencyCode: 'USD',
+      amountMinor: 7000,
+      amountBaseMinor: 7000,
+      exchangeRate: 1,
+      date: '2026-07-06',
+      isDebt: true,
+      debtDirection: DebtDirection.OWED_TO_ME,
+      debtStatus: DebtStatus.OPEN,
+      createdAt: '2026-07-06T00:00:00Z',
+      updatedAt: '2026-07-06T00:00:00Z',
+    } as any);
+
+    await repo.update('tx-2', {
+      isDebt: false,
+      type: 'INCOME' as any,
+    } as any);
+
+    expect(adjustBalance).toHaveBeenCalledWith('acc-1', 7000);
+  });
 });

--- a/tests/node/repositories/transactions-debt-parity.test.ts
+++ b/tests/node/repositories/transactions-debt-parity.test.ts
@@ -133,3 +133,260 @@ describe('transactions repository debt parity', () => {
     expect(localSummary).toEqual(expected);
   });
 });
+
+describe('debt with deduction (Supabase repo)', () => {
+  function buildSupabaseRpcMock() {
+    const rpcMock = jest.fn();
+
+    // Generic thenable chain: every call to `.then()` resolves the same
+    // default payload. `single()` is exposed at every level so ownership
+    // checks (`.from().select().eq().eq().single()`) and category lookups
+    // both work without per-test wiring.
+    const chain: any = {
+      select: jest.fn(),
+      eq: jest.fn(),
+      single: jest.fn(),
+      in: jest.fn(),
+      order: jest.fn(),
+      range: jest.fn(),
+      gte: jest.fn(),
+      lte: jest.fn(),
+      ilike: jest.fn(),
+      or: jest.fn(),
+      overlaps: jest.fn(),
+      then: jest.fn((resolve) =>
+        resolve({ data: { id: 'acc-1' }, error: null })
+      ),
+    };
+    chain.select.mockReturnValue(chain);
+    chain.eq.mockReturnValue(chain);
+    chain.single.mockResolvedValue({ data: { id: 'acc-1' }, error: null });
+    chain.in.mockReturnValue(chain);
+    chain.order.mockReturnValue(chain);
+    chain.range.mockReturnValue(chain);
+    chain.gte.mockReturnValue(chain);
+    chain.lte.mockReturnValue(chain);
+    chain.ilike.mockReturnValue(chain);
+    chain.or.mockReturnValue(chain);
+    chain.overlaps.mockReturnValue(chain);
+
+    const fromMock = jest.fn(() => chain);
+    const authGetUserMock = jest.fn().mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null,
+    });
+    return {
+      rpc: rpcMock,
+      from: fromMock,
+      auth: { getUser: authGetUserMock },
+    };
+  }
+
+  it('routes debt + deductFromAccount to create_debt_with_deduction', async () => {
+    const client = buildSupabaseRpcMock();
+    client.rpc.mockResolvedValue({
+      data: { debt_id: 'debt-1', expense_id: 'exp-1', debt_deducted: true },
+      error: null,
+    });
+
+    // The repo's create() for debt+deduct first calls the RPC, then
+    // findById() to re-fetch the debt row. findById() requires the
+    // owned-accounts scope to resolve, so the `from('accounts')` chain
+    // must yield an array; the `from('transactions')` chain must yield
+    // a single row.
+    const accountsRows = [{ id: 'debt-acc' }, { id: 'cash-acc' }];
+    const debtRow = {
+      id: 'debt-1',
+      type: 'EXPENSE',
+      account_id: 'debt-acc',
+      amount_minor: 100000,
+      amount_base_minor: 100000,
+      currency_code: 'USD',
+      date: '2026-07-06',
+      is_debt: true,
+      debt_direction: DebtDirection.OWED_TO_ME,
+      debt_status: DebtStatus.OPEN,
+      created_at: '2026-07-06T00:00:00Z',
+      updated_at: '2026-07-06T00:00:00Z',
+    };
+    (client.from as jest.Mock).mockImplementation((table: string) => {
+      const chain: any = {
+        select: jest.fn(),
+        eq: jest.fn(),
+        in: jest.fn(),
+        single: jest.fn(),
+        then: jest.fn(),
+      };
+      chain.select.mockReturnValue(chain);
+      chain.eq.mockReturnValue(chain);
+      chain.in.mockReturnValue(chain);
+      // The accounts scope chain awaits via `.then(resolve)` (not
+      // `.single()`); the transactions chain awaits via `.single()`.
+      chain.then = jest.fn((resolve: any) =>
+        resolve({
+          data: table === 'accounts' ? accountsRows : null,
+          error: null,
+        })
+      );
+      chain.single = jest.fn().mockResolvedValue({
+        data: table === 'transactions' ? debtRow : null,
+        error: null,
+      });
+      return chain;
+    });
+    const repo = new SupabaseTransactionsRepository(client as any);
+
+    const result = await repo.create({
+      type: 'EXPENSE' as any,
+      accountId: 'debt-acc',
+      categoryId: 'cat-debt',
+      currencyCode: 'USD',
+      amountMinor: 100000,
+      date: '2026-07-06',
+      description: 'Lent to bob',
+      isDebt: true,
+      debtDirection: DebtDirection.OWED_TO_ME,
+      deductFromAccount: true,
+      sourceAccountId: 'cash-acc',
+    } as any);
+
+    expect(client.rpc).toHaveBeenCalledWith(
+      'create_debt_with_deduction',
+      expect.objectContaining({
+        p_deduct: true,
+        p_source_account_id: 'cash-acc',
+        p_debt_direction: DebtDirection.OWED_TO_ME,
+      })
+    );
+    expect(result.id).toBe('debt-1');
+  });
+
+  it('falls back to the legacy RPC when debt is false (no deduction path)', async () => {
+    const client = buildSupabaseRpcMock();
+    client.rpc.mockResolvedValue({
+      data: { id: 'tx-1' },
+      error: null,
+    });
+
+    // `from('categories')` must return a default category so the repo
+    // passes the ownership check. `from('accounts')` already returns the
+    // generic chain from buildSupabaseRpcMock (which resolves to id only).
+    const categoryChain: any = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({
+        data: { id: 'cat-1', user_id: 'user-1', is_default: true },
+        error: null,
+      }),
+    };
+    (client.from as jest.Mock).mockImplementation((table: string) => {
+      if (table === 'categories') return categoryChain;
+      // For other tables (accounts ownership check) return a new generic
+      // chain that resolves with id.
+      const c: any = {
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        single: jest
+          .fn()
+          .mockResolvedValue({ data: { id: 'acc-1' }, error: null }),
+      };
+      return c;
+    });
+
+    const repo = new SupabaseTransactionsRepository(client as any);
+
+    await repo.create({
+      type: 'EXPENSE' as any,
+      accountId: 'acc-1',
+      categoryId: 'cat-1',
+      currencyCode: 'USD',
+      amountMinor: 50000,
+      date: '2026-07-06',
+      description: 'Lunch',
+    } as any);
+
+    expect(client.rpc).toHaveBeenCalledWith(
+      'create_transaction_and_adjust_balance',
+      expect.any(Object)
+    );
+  });
+
+  it('rejects a deduct request when sourceAccountId is missing', async () => {
+    const client = buildSupabaseRpcMock();
+    const repo = new SupabaseTransactionsRepository(client as any);
+
+    await expect(
+      repo.create({
+        type: 'EXPENSE' as any,
+        accountId: 'debt-acc',
+        categoryId: 'cat-debt',
+        currencyCode: 'USD',
+        amountMinor: 100000,
+        date: '2026-07-06',
+        description: 'No source',
+        isDebt: true,
+        debtDirection: DebtDirection.OWE,
+        deductFromAccount: true,
+      } as any)
+    ).rejects.toThrow(/sourceAccountId is required/i);
+
+    expect(client.rpc).not.toHaveBeenCalled();
+  });
+
+  it('routes debt deletion through delete_transaction_and_adjust_balance', async () => {
+    const client = buildSupabaseRpcMock();
+    const updateChain: any = {
+      eq: jest.fn(() => updateChain),
+      select: jest.fn(() => updateChain),
+      single: jest.fn().mockResolvedValue({
+        data: {
+          id: 'd-1',
+          type: 'EXPENSE',
+          account_id: 'a-1',
+          amount_minor: 100000,
+          amount_base_minor: 100000,
+          currency_code: 'USD',
+          date: '2026-07-06',
+          is_debt: true,
+          debt_direction: DebtDirection.OWE,
+          debt_status: DebtStatus.OPEN,
+          created_at: '2026-07-06T00:00:00Z',
+          updated_at: '2026-07-06T00:00:00Z',
+        },
+        error: null,
+      }),
+    };
+    client.from = jest.fn(() => updateChain) as any;
+    client.rpc = jest.fn().mockResolvedValue({ data: null, error: null });
+
+    const repo = new SupabaseTransactionsRepository(client as any);
+    // Spy on findById to return a debt row
+    jest.spyOn(repo, 'findById').mockResolvedValue({
+      id: 'd-1',
+      type: 'EXPENSE' as any,
+      accountId: 'a-1',
+      categoryId: null,
+      currencyCode: 'USD',
+      amountMinor: 100000,
+      amountBaseMinor: 100000,
+      exchangeRate: 1,
+      date: '2026-07-06',
+      isDebt: true,
+      debtDirection: DebtDirection.OWE,
+      debtStatus: DebtStatus.OPEN,
+      createdAt: '2026-07-06T00:00:00Z',
+      updatedAt: '2026-07-06T00:00:00Z',
+    } as any);
+
+    // accountsRepository is optional; we ensure no rpc balance adjustment
+    // is called for the delete path on a debt.
+    await repo.delete('d-1');
+
+    // The delete RPC must run, but no inline balance update from create()
+    // would have happened for an existing debt.
+    expect(client.rpc).toHaveBeenCalledWith(
+      'delete_transaction_and_adjust_balance',
+      expect.objectContaining({ transaction_id_input: 'd-1' })
+    );
+  });
+});

--- a/tests/use-transaction-form-debt.test.tsx
+++ b/tests/use-transaction-form-debt.test.tsx
@@ -165,4 +165,112 @@ describe('useTransactionForm debt capture', () => {
     );
     expect(createMock).not.toHaveBeenCalled();
   });
+
+  it('defaults deductFromAccount to true and forwards it to the DTO', async () => {
+    const { result } = renderHook(() => useTransactionForm());
+
+    await waitFor(() => {
+      expect(result.current.accounts.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.setFormData((prev) => ({
+        ...prev,
+        type: TransactionType.EXPENSE,
+        accountId: 'acc-1',
+        categoryId: 'cat-expense',
+        amount: '50',
+        description: 'Debt with default deduct',
+        isDebt: true,
+        debtDirection: DebtDirection.OWE,
+        // no explicit deductFromAccount — should default to true
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDebt: true,
+        debtDirection: 'OWE',
+        deductFromAccount: true,
+      })
+    );
+  });
+
+  it('forwards sourceAccountId when the user picks one', async () => {
+    const { result } = renderHook(() => useTransactionForm());
+
+    await waitFor(() => {
+      expect(result.current.accounts.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.setFormData((prev) => ({
+        ...prev,
+        type: TransactionType.EXPENSE,
+        accountId: 'acc-1',
+        categoryId: 'cat-expense',
+        amount: '75.25',
+        description: 'Debt with explicit source',
+        isDebt: true,
+        debtDirection: DebtDirection.OWE,
+        deductFromAccount: true,
+        sourceAccountId: 'acc-1',
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDebt: true,
+        debtDirection: 'OWE',
+        deductFromAccount: true,
+        sourceAccountId: 'acc-1',
+        amountMinor: 7525,
+      })
+    );
+  });
+
+  it('forwards deductFromAccount=false when the user opts out', async () => {
+    const { result } = renderHook(() => useTransactionForm());
+
+    await waitFor(() => {
+      expect(result.current.accounts.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.setFormData((prev) => ({
+        ...prev,
+        type: TransactionType.EXPENSE,
+        accountId: 'acc-1',
+        categoryId: 'cat-expense',
+        amount: '15',
+        description: 'Debt with no deduction',
+        isDebt: true,
+        debtDirection: DebtDirection.OWE,
+        deductFromAccount: false,
+      }));
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isDebt: true,
+        deductFromAccount: false,
+      })
+    );
+    // The DTO must NOT carry an accidental sourceAccountId when the user
+    // opted out of deduction.
+    const call = createMock.mock.calls[0][0];
+    expect(call.sourceAccountId).toBeUndefined();
+  });
 });

--- a/tests/use-transaction-form-debt.test.tsx
+++ b/tests/use-transaction-form-debt.test.tsx
@@ -166,7 +166,7 @@ describe('useTransactionForm debt capture', () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
-  it('defaults deductFromAccount to true and forwards it to the DTO', async () => {
+  it('defaults debt creation to metadata-only when no source account is selected', async () => {
     const { result } = renderHook(() => useTransactionForm());
 
     await waitFor(() => {
@@ -183,7 +183,8 @@ describe('useTransactionForm debt capture', () => {
         description: 'Debt with default deduct',
         isDebt: true,
         debtDirection: DebtDirection.OWE,
-        // no explicit deductFromAccount — should default to true
+        // no explicit sourceAccountId — shared/mobile flow should submit
+        // metadata-only instead of triggering repository validation errors
       }));
     });
 
@@ -195,9 +196,11 @@ describe('useTransactionForm debt capture', () => {
       expect.objectContaining({
         isDebt: true,
         debtDirection: 'OWE',
-        deductFromAccount: true,
+        deductFromAccount: false,
       })
     );
+    const call = createMock.mock.calls[0][0];
+    expect(call.sourceAccountId).toBeUndefined();
   });
 
   it('forwards sourceAccountId when the user picks one', async () => {

--- a/types/domain.ts
+++ b/types/domain.ts
@@ -217,6 +217,18 @@ export interface CreateTransactionDTO {
   debtStatus?: DebtStatus;
   counterpartyName?: string;
   settledAt?: string;
+  /**
+   * Debt-only: when true (default in the form), the repository will
+   * create a linked EXPENSE that debits `sourceAccountId` atomically
+   * with the debt row. When false, the debt is metadata only and no
+   * balance is touched.
+   */
+  deductFromAccount?: boolean;
+  /**
+   * Debt-only: the account that should be debited by the linked
+   * EXPENSE. Required when `deductFromAccount` is true.
+   */
+  sourceAccountId?: string;
 }
 
 export interface CreateTransferDTO {


### PR DESCRIPTION
Closes #13

## PR Type
- [x] Bug fix

## Summary
- Stop debt transactions from inflating available account balances with an app-flagged Supabase migration and local/Supabase parity.
- Add atomic debt-with-source-account deduction via RPC/local transaction and wire the debt form DTO safely.
- Configure GGA to use DeepSeek via OpenCode and add focused migration/repository/form tests.

## Changes
| File | Change |
|------|--------|
| `supabase/migrations/20260706120000_debt_balance_skip.sql` | Adds `app_flags`, RLS, debt balance skip guard, and safe legacy reversal cutoff. |
| `supabase/migrations/20260706120100_create_debt_with_deduction_rpc.sql` | Adds atomic debt + linked expense RPC with currency/category validation. |
| `repositories/*/transactions-repository-impl.ts` | Mirrors debt skip and source-account deduction behavior. |
| `hooks/use-transaction-form.ts`, `components/forms/transaction-form.tsx` | Sends safe debt deduction DTO fields and metadata-only fallback when no source account exists. |
| `tests/**/*debt*` | Adds migration, repository, hook, and form coverage. |
| `.gga` | Switches GGA provider to DeepSeek via OpenCode. |

## Test Plan
- [x] `npm run test:ci` — 208 passed, 2 skipped suites; 1384 passed, 8 skipped tests.
- [x] Supabase hook checks passed during commit hooks.
- [x] `npm run type-check` passed.
- [x] `node scripts/guardrails/check-direct-db-access.mjs` passed.
- [x] `npm run build` passed during push hook.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers