### PR TITLE
chore(tests): fix pre-existing TypeScript errors in test files (unblock husky)

### DIFF
--- a/tests/components/accounts/accounts-rates-panel.test.tsx
+++ b/tests/components/accounts/accounts-rates-panel.test.tsx
@@ -55,6 +55,7 @@ describe('AccountsRatesPanel', () => {
         bcv={mockBcv}
         binance={mockBinance}
         selectedSource="bcv_usd"
+        onOpenHistory={jest.fn()}
       />
     );
     expect(screen.getByTestId('accounts-rates-panel')).toBeInTheDocument();
@@ -66,6 +67,7 @@ describe('AccountsRatesPanel', () => {
         bcv={mockBcv}
         binance={mockBinance}
         selectedSource="bcv_usd"
+        onOpenHistory={jest.fn()}
       />
     );
     expect(screen.getByTestId('bcv-card')).toBeInTheDocument();
@@ -78,6 +80,7 @@ describe('AccountsRatesPanel', () => {
         bcv={mockBcv}
         binance={mockBinance}
         selectedSource="binance"
+        onOpenHistory={jest.fn()}
       />
     );
     const strip = screen.getByTestId('selected-rate-strip');
@@ -91,6 +94,7 @@ describe('AccountsRatesPanel', () => {
         bcv={mockBcv}
         binance={mockBinance}
         selectedSource="binance"
+        onOpenHistory={jest.fn()}
       />
     );
     expect(screen.getByTestId('selected-rate-strip')).toHaveTextContent(
@@ -102,6 +106,7 @@ describe('AccountsRatesPanel', () => {
         bcv={mockBcv}
         binance={mockBinance}
         selectedSource="bcv_usd"
+        onOpenHistory={jest.fn()}
       />
     );
     expect(screen.getByTestId('selected-rate-strip')).toHaveTextContent(

--- a/tests/dom/app/goals/page.test.tsx
+++ b/tests/dom/app/goals/page.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import GoalsPage from '@/app/goals/page';
 import { useRepository } from '@/providers/repository-provider';
 import { useAuth } from '@/hooks/use-auth';
-import { useUI } from '@/hooks';
 import { toast } from 'sonner';
 
 jest.mock('@/providers/repository-provider', () => ({
@@ -25,7 +24,6 @@ jest.mock('@/hooks/use-currency-converter', () => ({
 const modalState = { activeModal: null as string | null };
 
 jest.mock('@/hooks', () => ({
-  useUI: jest.fn(),
   useModal: jest.fn(() => ({
     isOpen: modalState.activeModal !== null,
     openModal: (id: string) => {
@@ -120,11 +118,6 @@ describe('GoalsPage accounts wiring + error surfacing', () => {
     modalState.activeModal = null;
     const repository = buildRepository();
     (useRepository as jest.Mock).mockReturnValue(repository);
-    (useUI as jest.Mock).mockReturnValue({
-      activeModal: null,
-      openModal: jest.fn(),
-      closeModal: jest.fn(),
-    });
 
     render(<GoalsPage />);
 
@@ -149,11 +142,6 @@ describe('GoalsPage accounts wiring + error surfacing', () => {
     modalState.activeModal = 'new-goal';
     const repository = buildRepository();
     (useRepository as jest.Mock).mockReturnValue(repository);
-    (useUI as jest.Mock).mockReturnValue({
-      activeModal: 'new-goal',
-      openModal: jest.fn(),
-      closeModal: jest.fn(),
-    });
 
     render(<GoalsPage />);
 
@@ -181,11 +169,6 @@ describe('GoalsPage accounts wiring + error surfacing', () => {
       createError: new Error('Failed to create goal: invalid_account_fk'),
     });
     (useRepository as jest.Mock).mockReturnValue(repository);
-    (useUI as jest.Mock).mockReturnValue({
-      activeModal: 'new-goal',
-      openModal: jest.fn(),
-      closeModal: jest.fn(),
-    });
 
     const user = userEvent.setup();
     render(<GoalsPage />);

--- a/tests/node/api/rates-fallback-route.test.ts
+++ b/tests/node/api/rates-fallback-route.test.ts
@@ -20,8 +20,8 @@ describe('BCV and Binance rate routes', () => {
     warn: jest.fn(),
     error: jest.fn(),
   };
-  const mockScrapeBCVRates = jest.fn();
-  const mockScrapeBinanceRates = jest.fn();
+  const mockScrapeBCVRates: any = jest.fn();
+  const mockScrapeBinanceRates: any = jest.fn();
 
   beforeEach(() => {
     jest.resetModules();

--- a/tests/node/api/recurring-transactions-cron.test.ts
+++ b/tests/node/api/recurring-transactions-cron.test.ts
@@ -1,3 +1,4 @@
+import { NextRequest } from 'next/server';
 import { GET, POST } from '@/app/api/cron/recurring-transactions/route';
 import { createServiceClient } from '@/lib/supabase/admin';
 import { createServerAppRepository } from '@/repositories/factory';
@@ -66,7 +67,7 @@ describe('Recurring Transactions Cron Route', () => {
   });
 
   it('returns 401 if CRON_SECRET header is missing or incorrect', async () => {
-    const request = new Request('http://localhost/api/cron/recurring-transactions', {
+    const request = new NextRequest('http://localhost/api/cron/recurring-transactions', {
       headers: {
         Authorization: 'Bearer wrong-key',
       },
@@ -80,7 +81,7 @@ describe('Recurring Transactions Cron Route', () => {
   });
 
   it('runs successfully with empty due transactions list', async () => {
-    const request = new Request('http://localhost/api/cron/recurring-transactions', {
+    const request = new NextRequest('http://localhost/api/cron/recurring-transactions', {
       headers: {
         Authorization: 'Bearer super-secret-cron-key',
       },
@@ -109,7 +110,7 @@ describe('Recurring Transactions Cron Route', () => {
     mockAdminRepo.recurringTransactions.findDueForExecution.mockResolvedValueOnce(mockDue);
     mockUserRepo.recurringTransactions.executeDue.mockResolvedValueOnce('new-tx-1');
 
-    const request = new Request('http://localhost/api/cron/recurring-transactions', {
+    const request = new NextRequest('http://localhost/api/cron/recurring-transactions', {
       headers: {
         Authorization: 'Bearer super-secret-cron-key',
       },
@@ -150,7 +151,7 @@ describe('Recurring Transactions Cron Route', () => {
     mockUserRepo.exchangeRates.getRateWithFallback.mockResolvedValueOnce({ rate: 40.0 });
     mockUserRepo.recurringTransactions.executeDue.mockResolvedValueOnce('new-ves-tx');
 
-    const request = new Request('http://localhost/api/cron/recurring-transactions', {
+    const request = new NextRequest('http://localhost/api/cron/recurring-transactions', {
       headers: {
         Authorization: 'Bearer super-secret-cron-key',
       },
@@ -196,7 +197,7 @@ describe('Recurring Transactions Cron Route', () => {
       .mockRejectedValueOnce(new Error('RPC failed'))
       .mockResolvedValueOnce('success-tx');
 
-    const request = new Request('http://localhost/api/cron/recurring-transactions', {
+    const request = new NextRequest('http://localhost/api/cron/recurring-transactions', {
       headers: {
         Authorization: 'Bearer super-secret-cron-key',
       },

--- a/tests/node/repositories/goals-supabase-ledger.test.ts
+++ b/tests/node/repositories/goals-supabase-ledger.test.ts
@@ -332,7 +332,9 @@ describe('SupabaseGoalsRepository ledger and refresh semantics', () => {
         accountId: '  acc-3  ',
       },
     ]);
-    const bulkPayload = lastInsertPayload() as Array<Record<string, unknown>>;
+    const bulkPayload = lastInsertPayload() as unknown as Array<
+      Record<string, unknown>
+    >;
     expect(bulkPayload).toHaveLength(2);
     expect(bulkPayload[0]).toEqual(
       expect.objectContaining({ target_date: null, account_id: null })

--- a/tests/providers/use-subscription-wrapper.test.tsx
+++ b/tests/providers/use-subscription-wrapper.test.tsx
@@ -41,7 +41,12 @@ describe('useSubscription wrapper', () => {
       subscription: null,
       tier: 'premium' as const,
       usage: null,
-      usageStatus: null,
+      usageStatus: {
+        transactions: { current: 0, limit: 'unlimited', percentage: 0 },
+        backups: { current: 0, limit: 'unlimited', percentage: 0 },
+        exports: { current: 0, limit: 'unlimited', percentage: 0 },
+        aiRequests: { current: 0, limit: 'unlimited', percentage: 0 },
+      } as const,
       limits: {} as any,
     };
 

--- a/tests/unit/hooks/use-debt-actions.test.ts
+++ b/tests/unit/hooks/use-debt-actions.test.ts
@@ -119,7 +119,11 @@ describe('useDebtActions', () => {
       );
 
       await act(async () => {
-        await result.current.settleDebt(debtWithoutId);
+        await result.current.settleDebt(debtWithoutId, {
+          amountMinor: 5000,
+          settlementAccountId: 'acc-1',
+          date: '2026-07-07T00:00:00.000Z',
+        });
       });
 
       expect(updateMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Qué

Arregla **errores de TypeScript pre-existentes en archivos de tests** que hacían fallar los hooks de husky (pre-commit/pre-push corren typecheck). Son **test-only** — no afectan el build de producción (`next build` no typechequea tests).

Motivación: los hooks obligaban a usar `--no-verify` por esta deuda. Al limpiarla (junto con PR #16), `main` queda en **tsc-cero** y los hooks pasan sin bypass.

## Fixes (7 archivos, correctos — no silenciados)

| Archivo | Fix |
|---|---|
| `accounts-rates-panel.test.tsx` | pasar el prop requerido `onOpenHistory` en los 5 renders |
| `dom/app/goals/page.test.tsx` | eliminar mock muerto de `useUI` (la página usa `useModal`) |
| `node/api/rates-fallback-route.test.ts` | tipar los mocks de scrapers para que `mockResolvedValue` no infiera `never` |
| `node/api/recurring-transactions-cron.test.ts` | usar `NextRequest` en vez de `Request` |
| `node/repositories/goals-supabase-ledger.test.ts` | corregir el cast del payload de bulk-insert |
| `providers/use-subscription-wrapper.test.tsx` | mock de `UsageStatus` válido (requerido, no `null`) |
| `unit/hooks/use-debt-actions.test.ts` | pasar el arg `input` requerido a `settleDebt` en el test de "sin id" |

## Verificación

- **Sin cambios en código de producción** (solo tests).
- `tsc --noEmit` **limpio** para los 7 archivos.
- Los **7 suites pasan (29 tests)** — corridos desde un checkout de path limpio (Jest no corre desde `.claude/worktrees` en Windows por el bug de glob de `next/jest`).
- Ningún error reveló un bug real de producción; todos eran de tipado en tests (props faltantes, mocks stale, inferencia débil de `jest.fn()`, tipo `Request` incorrecto, payloads de mock incompletos).

## Relación con otras PRs

Los errores de typecheck restantes en `main` (`settleDebt` faltante + `partial-debt-settlements.test.ts`) los cubre **#16**. Al mergear ambas, `main` queda sin errores de typecheck y husky pasa sin `--no-verify`.
