### PR TITLE
test(transactions): fix CI — add missing or() to ownership-scope query mock

### DIFF
--- a/tests/node/repositories/transactions-ownership-scope.test.ts
+++ b/tests/node/repositories/transactions-ownership-scope.test.ts
@@ -72,6 +72,7 @@ describe('SupabaseTransactionsRepository ownership scoping', () => {
           }
           return query;
         }),
+        or: jest.fn(() => query),
         order: jest.fn(() => query),
         range: jest.fn(() => query),
         then: (resolve: (value: unknown) => void) => {


### PR DESCRIPTION
## Qué

El job **Required checks → Test** del CI falla en `transactions-ownership-scope.test.ts` con:

```
TypeError: query.or is not a function
  at SupabaseTransactionsRepository.findByFilters (repositories/supabase/transactions-repository-impl.ts:254)
```

## Por qué

El feature de ocultar transacciones `debt-linked` (commits `77c2283`/`38c0768`) agregó llamadas `query.or(...)` incondicionales en `findByFilters`. El mock de query de este test —que valida ownership scoping— quedó viejo: solo exponía `in`, `order`, `range` y `then`, sin `or`.

## Fix

Agrego `or: jest.fn(() => query)` como passthrough al mock, igual que sus hermanos chainables. El test de ownership no depende del filtro `.or` (su `then` filtra solo por `scopedAccountIds`), así que es un no-op seguro.

## Verificación

```
PASS tests/node/repositories/transactions-ownership-scope.test.ts
  √ returns only transactions for owned accounts
  √ returns safe empty result when user owns no accounts
```

> Nota: las lanes E2E de Playwright (no-auth / auth-required) también fallan en CI y quedan fuera de este PR — requieren investigación aparte.