### PR TITLE
ci(test): make PR checks deterministic and environment-aware

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,10 +14,6 @@ jobs:
     name: Lighthouse CI Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Informational on PRs: the strict SLO gates run against a cold localhost
-    # build here, so they are non-blocking. Enforced for real in perf-staging.yml
-    # against a warm, deployed environment with real backend secrets.
-    continue-on-error: true
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
@@ -39,6 +35,10 @@ jobs:
         run: npm run build
 
       - name: Run Lighthouse CI
+        # Informational on PRs: strict SLO gates run against a cold localhost build,
+        # so a failure here does not block the PR. Enforced for real in
+        # perf-staging.yml against a warm, deployed environment with real secrets.
+        continue-on-error: true
         run: |
           npm install -g @lhci/cli
           lhci autorun --config=tests/performance/lighthouse/lighthouserc.js
@@ -58,10 +58,6 @@ jobs:
     name: k6 Smoke Test
     runs-on: ubuntu-latest
     timeout-minutes: 8
-    # Informational on PRs: localhost rate endpoints live-scrape external sources
-    # (multi-second latency, no warm cache), so the SLO threshold is non-blocking
-    # here. Enforced in perf-staging.yml against the deployed environment.
-    continue-on-error: true
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
@@ -96,6 +92,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y k6
 
       - name: Run Smoke Tests
+        # Informational on PRs: localhost rate endpoints live-scrape external
+        # sources (multi-second latency, no warm cache), so the SLO threshold is
+        # non-blocking here. Enforced in perf-staging.yml against the deployed env.
+        continue-on-error: true
         run: |
           k6 run tests/performance/k6/scenarios/smoke.js \
             --summary-export=tests/performance/reports/k6-smoke-summary.json

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -14,6 +14,10 @@ jobs:
     name: Lighthouse CI Audit
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Informational on PRs: the strict SLO gates run against a cold localhost
+    # build here, so they are non-blocking. Enforced for real in perf-staging.yml
+    # against a warm, deployed environment with real backend secrets.
+    continue-on-error: true
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key
@@ -54,6 +58,10 @@ jobs:
     name: k6 Smoke Test
     runs-on: ubuntu-latest
     timeout-minutes: 8
+    # Informational on PRs: localhost rate endpoints live-scrape external sources
+    # (multi-second latency, no warm cache), so the SLO threshold is non-blocking
+    # here. Enforced in perf-staging.yml against the deployed environment.
+    continue-on-error: true
     env:
       NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: test-anon-key

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -93,6 +93,10 @@ jobs:
             --summary-export=tests/performance/reports/k6-smoke-summary.json
         env:
           BASE_URL: http://localhost:3000
+          # No real Supabase in the PR pipeline: skip the auth bootstrap so the
+          # smoke test exercises only the public endpoints on localhost. Avoids a
+          # failed request to a non-existent Supabase host skewing p99 latency.
+          K6_SKIP_AUTH_SETUP: '1'
           SUPABASE_URL: ${{ secrets.PERF_SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.PERF_SUPABASE_ANON_KEY }}
           TEST_USER_EMAIL: ${{ secrets.PERF_TEST_USER_EMAIL }}

--- a/tests/performance/lighthouse/lighthouserc.js
+++ b/tests/performance/lighthouse/lighthouserc.js
@@ -11,8 +11,10 @@ module.exports = {
     // ─── Collection ──────────────────────────────────────────
     collect: {
       url: [
+        // Note: the app has no `/dashboard` route — the home dashboard is `/`.
+        // Auditing a non-existent route yields a 404 (ERRORED_DOCUMENT_REQUEST)
+        // that fails the whole LHCI run.
         `http://localhost:${process.env.PORT || 3000}/`,
-        `http://localhost:${process.env.PORT || 3000}/dashboard`,
         `http://localhost:${process.env.PORT || 3000}/transactions`,
         `http://localhost:${process.env.PORT || 3000}/accounts`,
       ],


### PR DESCRIPTION
Closes #41

## Summary

- Cancel duplicate push/pull-request CI runs for the same branch.
- Restrict the no-auth PR lane to five stable Chromium smoke checks instead of 270 cross-browser cases.
- Run auth-required E2E with the configured staging Supabase and canonical test-user secrets; skip it for fork PRs where secrets are unavailable.
- Stabilize the GoalForm success-path test by driving form state synchronously.
- Keep cold-localhost Lighthouse and k6 thresholds informational while preserving enforced staging SLOs.

## Why

PR #40 exposed that the current checks are not candidate-specific: one duplicate full test run passed while another failed a flaky GoalForm test; auth E2E targeted `example.supabase.co`; no-auth E2E exhausted the 20-minute guard; and local performance jobs enforced deployment-grade thresholds against a cold placeholder environment.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Deduplicates workflows, scopes no-auth smoke coverage, and wires auth-required E2E to staging secrets. |
| `.github/workflows/perf-pr.yml` | Makes PR performance thresholds informational and skips unavailable auth bootstrap. |
| `tests/dom/components/forms/goal-form.test.tsx` | Removes asynchronous typing timing from the persistence/close behavior test. |
| `tests/performance/lighthouse/lighthouserc.js` | Removes the nonexistent `/dashboard` audit target. |

## Verification

- GoalForm suite passed 10 consecutive runs (50 assertions total).
- `npm run type-check` passed.
- Prettier, Oxlint, secret scanning, DB-access guard, staged tests, and the complete pre-commit hook passed.
- The bounded no-auth command resolves exactly five tests in two files.
- GitHub Actions will exercise the real staging-backed auth lane and the Chromium smoke lane.