### PR TITLE
feat(ai-rag): embeddings client + fail-open reranker (PR2/3)

### DIFF
--- a/lib/ai/rag/embeddings.ts
+++ b/lib/ai/rag/embeddings.ts
@@ -1,0 +1,128 @@
+import { embed } from 'ai';
+import { google } from '@ai-sdk/google';
+
+/**
+ * gemini-embedding-001 embedding module.
+ *
+ * Design notes (see sdd/ai-rag-hybrid-search/design):
+ * - Requests 768 output dimensions via `providerOptions.google.outputDimensionality`.
+ * - gemini-embedding-001 only normalizes its output at the native 3072-dim
+ *   size, so any truncated/projected dimensionality (768 here) is NOT
+ *   guaranteed to be unit length — we renormalize client-side before use.
+ * - We assert the returned vector length is exactly 768 before renormalizing.
+ *   This guards against a historical AI SDK passthrough bug (vercel/ai#8033)
+ *   where `outputDimensionality` was silently ignored by some provider paths
+ *   and the full 3072-dim vector leaked through.
+ * - Query embeddings (taskType=RETRIEVAL_QUERY) are cached in a module-scope
+ *   LRU cache to avoid recomputing identical repeated searches within a
+ *   session. Document embeddings (RETRIEVAL_DOCUMENT) are never cached since
+ *   each write is expected to produce a fresh, distinct embedding.
+ */
+
+export type EmbeddingTaskType = 'RETRIEVAL_DOCUMENT' | 'RETRIEVAL_QUERY';
+
+const EMBEDDING_MODEL_ID = 'gemini-embedding-001';
+export const EMBEDDING_DIMENSIONS = 768;
+const QUERY_CACHE_MAX_ENTRIES = 100;
+
+/**
+ * Module-scope LRU cache for query embeddings, keyed by raw query text.
+ * Map preserves insertion order, which we use as the recency ordering:
+ * re-inserting a key on access moves it to the "most recently used" end.
+ */
+const queryEmbeddingCache = new Map<string, number[]>();
+
+function getCachedQueryEmbedding(text: string): number[] | undefined {
+  const cached = queryEmbeddingCache.get(text);
+  if (cached === undefined) {
+    return undefined;
+  }
+  // Refresh recency: move this entry to the end.
+  queryEmbeddingCache.delete(text);
+  queryEmbeddingCache.set(text, cached);
+  return cached;
+}
+
+function setCachedQueryEmbedding(text: string, embedding: number[]): void {
+  if (queryEmbeddingCache.has(text)) {
+    queryEmbeddingCache.delete(text);
+  } else if (queryEmbeddingCache.size >= QUERY_CACHE_MAX_ENTRIES) {
+    const oldestKey = queryEmbeddingCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      queryEmbeddingCache.delete(oldestKey);
+    }
+  }
+  queryEmbeddingCache.set(text, embedding);
+}
+
+/** Test-only helper to reset LRU cache state between test cases. */
+export function clearQueryEmbeddingCache(): void {
+  queryEmbeddingCache.clear();
+}
+
+function magnitude(vector: number[]): number {
+  return Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+}
+
+/**
+ * Renormalizes an embedding vector to unit length (L2 norm = 1).
+ * A zero vector is returned unchanged (renormalizing would divide by zero).
+ */
+export function renormalize(vector: number[]): number[] {
+  const norm = magnitude(vector);
+  if (norm === 0) {
+    return vector;
+  }
+  return vector.map((value) => value / norm);
+}
+
+function assertEmbeddingLength(embedding: number[]): void {
+  if (embedding.length !== EMBEDDING_DIMENSIONS) {
+    throw new Error(
+      `Expected a ${EMBEDDING_DIMENSIONS}-dimension embedding from ${EMBEDDING_MODEL_ID}, ` +
+        `but received ${embedding.length} dimensions. This likely indicates the provider ` +
+        `ignored providerOptions.google.outputDimensionality (see vercel/ai#8033) — ` +
+        `refusing to persist a mismatched vector.`
+    );
+  }
+}
+
+/**
+ * Generates a 768-dimension embedding for `text` using gemini-embedding-001.
+ *
+ * - `taskType=RETRIEVAL_DOCUMENT` for text being stored (transaction descriptions).
+ * - `taskType=RETRIEVAL_QUERY` for search queries; results are cached.
+ *
+ * @throws if the provider returns a vector whose length is not exactly 768.
+ */
+export async function embedText(
+  text: string,
+  taskType: EmbeddingTaskType
+): Promise<number[]> {
+  if (taskType === 'RETRIEVAL_QUERY') {
+    const cached = getCachedQueryEmbedding(text);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
+  const { embedding } = await embed({
+    model: google.textEmbeddingModel(EMBEDDING_MODEL_ID),
+    value: text,
+    providerOptions: {
+      google: {
+        outputDimensionality: EMBEDDING_DIMENSIONS,
+        taskType,
+      },
+    },
+  });
+
+  assertEmbeddingLength(embedding);
+  const normalized = renormalize(embedding);
+
+  if (taskType === 'RETRIEVAL_QUERY') {
+    setCachedQueryEmbedding(text, normalized);
+  }
+
+  return normalized;
+}

--- a/lib/ai/rag/reranker.ts
+++ b/lib/ai/rag/reranker.ts
@@ -1,0 +1,147 @@
+/**
+ * Fail-open reranker for hybrid search candidates.
+ *
+ * Design notes (see sdd/ai-rag-hybrid-search/design):
+ * - Voyage `rerank-2.5-lite` is called through the Vercel AI Gateway HTTP
+ *   endpoint, gated behind the `RERANKER_ENABLED` feature flag.
+ * - Bounded by a hard ~500ms timeout via `AbortController`.
+ * - MUST fail open (return the input order unchanged) on any error, timeout,
+ *   non-ok response, or when the flag is disabled — reranking is purely an
+ *   optimization on top of the RRF-ordered candidates, never a hard
+ *   dependency of search.
+ * - Skip heuristics avoid the network round-trip entirely when it would add
+ *   little value: fewer than 15 candidates, or a strong exact lexical match
+ *   already present among the candidates for the query text.
+ */
+
+export interface RerankCandidate {
+  id: string;
+  text: string;
+  score: number;
+}
+
+interface VoyageRerankResult {
+  index: number;
+  relevance_score: number;
+}
+
+interface VoyageRerankResponse {
+  results?: VoyageRerankResult[];
+}
+
+const RERANK_TIMEOUT_MS = 500;
+const MIN_CANDIDATES_FOR_RERANK = 15;
+const RERANK_MODEL = 'voyage/rerank-2.5-lite';
+const DEFAULT_GATEWAY_RERANK_URL = 'https://ai-gateway.vercel.sh/v1/rerank';
+
+function isRerankerEnabled(): boolean {
+  return process.env.RERANKER_ENABLED === 'true';
+}
+
+function getGatewayRerankUrl(): string {
+  return process.env.AI_GATEWAY_RERANK_URL || DEFAULT_GATEWAY_RERANK_URL;
+}
+
+/**
+ * True when the query text appears verbatim (case-insensitive) inside any
+ * candidate's text — a strong signal that lexical matching already found
+ * the right answer and semantic reranking would add little value.
+ */
+function hasStrongLexicalAnchor(
+  query: string,
+  candidates: RerankCandidate[]
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return false;
+  }
+  return candidates.some((candidate) =>
+    candidate.text.toLowerCase().includes(normalizedQuery)
+  );
+}
+
+function applyRerankOrder(
+  candidates: RerankCandidate[],
+  response: VoyageRerankResponse
+): RerankCandidate[] {
+  const results = response.results;
+  if (!Array.isArray(results) || results.length === 0) {
+    return candidates;
+  }
+
+  const sorted = [...results].sort(
+    (a, b) => b.relevance_score - a.relevance_score
+  );
+  const reranked = sorted
+    .map((result) => candidates[result.index])
+    .filter(
+      (candidate): candidate is RerankCandidate => candidate !== undefined
+    );
+
+  return reranked.length > 0 ? reranked : candidates;
+}
+
+async function callGatewayRerank(
+  query: string,
+  candidates: RerankCandidate[]
+): Promise<VoyageRerankResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), RERANK_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(getGatewayRerankUrl(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.AI_GATEWAY_API_KEY ?? ''}`,
+      },
+      body: JSON.stringify({
+        model: RERANK_MODEL,
+        query,
+        documents: candidates.map((candidate) => candidate.text),
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Reranker gateway request failed with status ${response.status}`
+      );
+    }
+
+    return (await response.json()) as VoyageRerankResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Reranks `candidates` for `query` via Voyage rerank-2.5-lite through the
+ * Vercel AI Gateway. Always fails open to the original (RRF-ordered) input
+ * on any error, timeout, disabled flag, or skip heuristic.
+ */
+export async function rerankCandidates(
+  query: string,
+  candidates: RerankCandidate[]
+): Promise<RerankCandidate[]> {
+  if (!isRerankerEnabled()) {
+    return candidates;
+  }
+  if (candidates.length < MIN_CANDIDATES_FOR_RERANK) {
+    return candidates;
+  }
+  if (hasStrongLexicalAnchor(query, candidates)) {
+    return candidates;
+  }
+
+  try {
+    const response = await callGatewayRerank(query, candidates);
+    return applyRerankOrder(candidates, response);
+  } catch (error) {
+    console.warn(
+      '[reranker] falling back to RRF order:',
+      error instanceof Error ? error.message : String(error)
+    );
+    return candidates;
+  }
+}

--- a/tests/node/lib/ai/rag/embeddings.test.ts
+++ b/tests/node/lib/ai/rag/embeddings.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for `lib/ai/rag/embeddings.ts`.
+ *
+ * Mocks the `ai` package's `embed()` and `@ai-sdk/google`'s
+ * `google.textEmbeddingModel()` — no live provider calls.
+ *
+ * Covers (per design + spec transaction-embeddings requirement):
+ *   - 768-dim length assertion (throws on mismatch — historical
+ *     vercel/ai#8033 passthrough bug)
+ *   - Client-side renormalization to unit length
+ *   - taskType branching (RETRIEVAL_DOCUMENT vs RETRIEVAL_QUERY)
+ *   - Module-scope LRU cache hit/miss for repeated query embeddings
+ */
+
+const mockEmbed = jest.fn();
+const mockTextEmbeddingModel = jest.fn((modelId: string) => ({
+  modelId,
+  __type: 'mock-embedding-model',
+}));
+
+jest.mock('ai', () => ({
+  embed: (...args: unknown[]) => mockEmbed(...args),
+}));
+
+jest.mock('@ai-sdk/google', () => ({
+  google: {
+    textEmbeddingModel: (...args: unknown[]) => mockTextEmbeddingModel(...args),
+  },
+}));
+
+function magnitude(vector: number[]): number {
+  return Math.sqrt(vector.reduce((sum, v) => sum + v * v, 0));
+}
+
+describe('lib/ai/rag/embeddings', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockEmbed.mockReset();
+    mockTextEmbeddingModel.mockClear();
+  });
+
+  describe('embedText — length assertion', () => {
+    it('returns a 768-length vector on a well-formed provider response', async () => {
+      const raw = Array.from({ length: 768 }, (_, i) => (i % 5) + 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+      const result = await embedText(
+        'coffee at starbucks',
+        'RETRIEVAL_DOCUMENT'
+      );
+
+      expect(result).toHaveLength(768);
+    });
+
+    it('throws when the provider returns a vector with the wrong length (passthrough bug guard)', async () => {
+      const raw = Array.from({ length: 3072 }, () => 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+
+      await expect(
+        embedText('coffee at starbucks', 'RETRIEVAL_DOCUMENT')
+      ).rejects.toThrow(/768/);
+    });
+  });
+
+  describe('embedText — renormalization', () => {
+    it('renormalizes a non-unit vector to unit length', async () => {
+      // 768 entries all set to 2 -> magnitude = sqrt(768 * 4) = sqrt(3072), not 1
+      const raw = Array.from({ length: 768 }, () => 2);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+      const result = await embedText(
+        'netflix subscription',
+        'RETRIEVAL_DOCUMENT'
+      );
+
+      expect(magnitude(result)).toBeCloseTo(1, 6);
+      // Direction preserved: every component should still be equal to each other
+      expect(result[0]).toBeCloseTo(result[1], 10);
+    });
+
+    it('renormalizes a different non-unit vector to unit length (triangulation)', async () => {
+      const raw = Array.from({ length: 768 }, (_, i) => (i < 384 ? 1 : 3));
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+      const result = await embedText(
+        'gas station fillup',
+        'RETRIEVAL_DOCUMENT'
+      );
+
+      expect(magnitude(result)).toBeCloseTo(1, 6);
+    });
+  });
+
+  describe('embedText — taskType branching', () => {
+    it('passes taskType=RETRIEVAL_DOCUMENT through providerOptions.google for stored text', async () => {
+      const raw = Array.from({ length: 768 }, () => 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+      await embedText('grocery store purchase', 'RETRIEVAL_DOCUMENT');
+
+      expect(mockEmbed).toHaveBeenCalledTimes(1);
+      const call = mockEmbed.mock.calls[0][0];
+      expect(call.providerOptions.google.taskType).toBe('RETRIEVAL_DOCUMENT');
+      expect(call.providerOptions.google.outputDimensionality).toBe(768);
+    });
+
+    it('passes taskType=RETRIEVAL_QUERY through providerOptions.google for search queries', async () => {
+      const raw = Array.from({ length: 768 }, () => 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+      await embedText('find my netflix charges', 'RETRIEVAL_QUERY');
+
+      expect(mockEmbed).toHaveBeenCalledTimes(1);
+      const call = mockEmbed.mock.calls[0][0];
+      expect(call.providerOptions.google.taskType).toBe('RETRIEVAL_QUERY');
+    });
+  });
+
+  describe('embedText — module-scope LRU cache for query embeddings', () => {
+    it('returns a cached result for a repeated RETRIEVAL_QUERY text without calling the provider again', async () => {
+      const raw = Array.from({ length: 768 }, () => 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+
+      const first = await embedText(
+        'find my netflix charges',
+        'RETRIEVAL_QUERY'
+      );
+      expect(mockEmbed).toHaveBeenCalledTimes(1);
+
+      const second = await embedText(
+        'find my netflix charges',
+        'RETRIEVAL_QUERY'
+      );
+
+      expect(mockEmbed).toHaveBeenCalledTimes(1); // no second provider call
+      expect(second).toEqual(first);
+    });
+
+    it('does not cache RETRIEVAL_DOCUMENT embeddings (each write re-embeds)', async () => {
+      const raw = Array.from({ length: 768 }, () => 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+
+      await embedText('same description twice', 'RETRIEVAL_DOCUMENT');
+      await embedText('same description twice', 'RETRIEVAL_DOCUMENT');
+
+      expect(mockEmbed).toHaveBeenCalledTimes(2);
+    });
+
+    it('misses the cache for a different query text', async () => {
+      const raw = Array.from({ length: 768 }, () => 1);
+      mockEmbed.mockResolvedValue({ embedding: raw });
+
+      const { embedText } = require('@/lib/ai/rag/embeddings');
+
+      await embedText('find my netflix charges', 'RETRIEVAL_QUERY');
+      await embedText('find my spotify charges', 'RETRIEVAL_QUERY');
+
+      expect(mockEmbed).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/node/lib/ai/rag/reranker.test.ts
+++ b/tests/node/lib/ai/rag/reranker.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for `lib/ai/rag/reranker.ts`.
+ *
+ * Mocks `global.fetch` (the Vercel AI Gateway HTTP call to Voyage
+ * rerank-2.5-lite) — no live network calls.
+ *
+ * Covers (per design's reranker decision + spec "Fail-open reranker"
+ * requirement, all 3 scenarios):
+ *   - Skip heuristics: fewer than 15 candidates, or a strong lexical anchor
+ *   - ~500ms hard timeout -> fail-open to original order
+ *   - Any error -> fail-open to original order
+ *   - Feature flag disabled -> fail-open (passthrough) without calling fetch
+ *   - Success path returns the reranked order
+ */
+
+const originalFetch = global.fetch;
+const originalEnv = process.env.RERANKER_ENABLED;
+
+function makeCandidates(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `tx-${i}`,
+    text: `Transaction number ${i} at Merchant ${i}`,
+    score: 1 / (50 + i),
+  }));
+}
+
+describe('lib/ai/rag/reranker', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.RERANKER_ENABLED = 'true';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.RERANKER_ENABLED = originalEnv;
+    jest.useRealTimers();
+  });
+
+  describe('skip heuristics', () => {
+    it('skips reranking and returns input order unchanged when fewer than 15 candidates', async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const candidates = makeCandidates(10);
+
+      const result = await rerankCandidates(
+        'find my netflix charges',
+        candidates
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result).toEqual(candidates);
+    });
+
+    it('skips reranking when a strong lexical anchor exists in a top candidate', async () => {
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const candidates = makeCandidates(20);
+      candidates[0] = {
+        id: 'tx-anchor',
+        text: 'netflix subscription charge',
+        score: 0.5,
+      };
+
+      const result = await rerankCandidates(
+        'netflix subscription charge',
+        candidates
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result).toEqual(candidates);
+    });
+  });
+
+  describe('feature flag', () => {
+    it('returns the input order unchanged and never calls fetch when the flag is disabled', async () => {
+      process.env.RERANKER_ENABLED = 'false';
+      const fetchMock = jest.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const candidates = makeCandidates(20);
+
+      const result = await rerankCandidates(
+        'find my netflix charges',
+        candidates
+      );
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(result).toEqual(candidates);
+    });
+  });
+
+  describe('fail-open behavior', () => {
+    it('falls open to the original RRF order when the gateway call errors', async () => {
+      const fetchMock = jest
+        .fn()
+        .mockRejectedValue(new Error('gateway unreachable'));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const candidates = makeCandidates(20);
+
+      const result = await rerankCandidates('find my transactions', candidates);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual(candidates);
+    });
+
+    it('falls open to the original RRF order when the gateway call times out (~500ms)', async () => {
+      const fetchMock = jest.fn().mockImplementation(
+        (_url: string, options: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            options.signal.addEventListener('abort', () => {
+              reject(new DOMException('Aborted', 'AbortError'));
+            });
+          })
+      );
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const candidates = makeCandidates(20);
+
+      const result = await rerankCandidates('find my transactions', candidates);
+
+      expect(result).toEqual(candidates);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, options] = fetchMock.mock.calls[0];
+      expect(options.signal.aborted).toBe(true);
+    }, 2000);
+
+    it('falls open to the original RRF order when the gateway responds with a non-ok status', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({}),
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const candidates = makeCandidates(20);
+
+      const result = await rerankCandidates('find my transactions', candidates);
+
+      expect(result).toEqual(candidates);
+    });
+  });
+
+  describe('success path', () => {
+    it('returns candidates reordered per the gateway relevance scores', async () => {
+      const candidates = makeCandidates(20);
+      // Gateway says candidate index 5 is most relevant, then index 0.
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          results: [
+            { index: 5, relevance_score: 0.98 },
+            { index: 0, relevance_score: 0.91 },
+            { index: 3, relevance_score: 0.4 },
+          ],
+        }),
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const { rerankCandidates } = require('@/lib/ai/rag/reranker');
+      const result = await rerankCandidates(
+        'find my netflix and spotify charges',
+        candidates
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result[0]).toEqual(candidates[5]);
+      expect(result[1]).toEqual(candidates[0]);
+      expect(result[2]).toEqual(candidates[3]);
+    });
+  });
+});


### PR DESCRIPTION
Recreates #24 (auto-closed by GitHub when its base branch was deleted after #23 merged). Same content, reviewed and approved under review lineage review-a7e0bbe185de6e9e. See #24 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)