### PR TITLE
fix(chat): full-height layout and dark-mode contrast polish

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,5 +1,4 @@
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+import { requireAuthenticatedUser } from '@/app/_lib/require-authenticated-user';
 import { MainLayout } from '@/components/layout/main-layout';
 import { Sparkles } from 'lucide-react';
 import type { Metadata } from 'next';
@@ -17,41 +16,36 @@ export const metadata: Metadata = {
  * Renders the chat interface for authenticated users within MainLayout.
  */
 export default async function ChatPage() {
-    const supabase = await createClient();
-    const { data: { user }, error } = await supabase.auth.getUser();
+  await requireAuthenticatedUser();
 
-    if (error || !user) {
-        redirect('/auth/login');
-    }
-
-    return (
-        <MainLayout>
-            <div className="flex h-full flex-col">
-                {/* Premium Header */}
-                <div className="border-b border-border/60 bg-card/80 px-4 py-3 backdrop-blur-xl sm:px-6">
-                    <div className="mx-auto flex max-w-3xl items-center gap-3">
-                        <div className="relative flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-blue-500 shadow-ios-sm">
-                            <Sparkles className="h-5 w-5 text-white" aria-hidden="true" />
-                            <span
-                                className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card bg-success"
-                                aria-hidden="true"
-                            />
-                        </div>
-                        <div className="min-w-0">
-                            <h1 className="truncate text-base font-semibold text-foreground">
-                                Asistente Financiero IA
-                            </h1>
-                            <p className="truncate text-xs text-muted-foreground">
-                                Pregúntame sobre tus finanzas
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                {/* Chat Interface - Full height */}
-                <div className="flex-1 overflow-hidden min-h-0">
-                    <ChatPageClient />
-                </div>
+  return (
+    <MainLayout>
+      <div className="flex min-h-0 flex-1 flex-col">
+        {/* Premium Header */}
+        <div className="border-b border-border/60 bg-card/80 px-4 py-3 backdrop-blur-xl sm:px-6">
+          <div className="mx-auto flex max-w-3xl items-center gap-3">
+            <div className="relative flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-blue-500 shadow-ios-sm">
+              <Sparkles className="h-5 w-5 text-white" aria-hidden="true" />
+              <span
+                className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card bg-success"
+                aria-hidden="true"
+              />
             </div>
-        </MainLayout>
-    );
+            <div className="min-w-0">
+              <h1 className="truncate text-base font-semibold text-foreground">
+                Asistente Financiero IA
+              </h1>
+              <p className="truncate text-xs text-muted-foreground">
+                Pregúntame sobre tus finanzas
+              </p>
+            </div>
+          </div>
+        </div>
+        {/* Chat Interface - Full height */}
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <ChatPageClient />
+        </div>
+      </div>
+    </MainLayout>
+  );
 }

--- a/components/ai/chat-input.tsx
+++ b/components/ai/chat-input.tsx
@@ -42,8 +42,8 @@ export function ChatInput({
         rows={1}
         aria-label="Mensaje para el asistente"
         className={cn(
-          'w-full resize-none rounded-3xl border border-border/60 bg-card py-3.5 pl-5 pr-14',
-          'text-[16px] md:text-sm placeholder:text-muted-foreground',
+          'w-full resize-none rounded-3xl border border-border bg-secondary/60 py-3.5 pl-5 pr-14',
+          'text-[16px] placeholder:text-muted-foreground md:text-sm',
           'shadow-ios-sm',
           'focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-primary/20',
           'disabled:cursor-not-allowed disabled:opacity-60',

--- a/components/ai/chat-interface.tsx
+++ b/components/ai/chat-interface.tsx
@@ -50,21 +50,25 @@ export function ChatInterface() {
       icon: Wallet,
       label: '¿Cuál es mi saldo?',
       query: '¿Cuál es mi saldo?',
+      iconClass: 'bg-primary/15 text-primary',
     },
     {
       icon: BarChart3,
       label: 'Mis gastos recientes',
       query: 'Muéstrame mis transacciones recientes',
+      iconClass: 'bg-success-500/15 text-success-400',
     },
     {
       icon: Target,
       label: 'Crear meta de ahorro',
       query: 'Crear una meta de ahorro',
+      iconClass: 'bg-warning-500/15 text-warning-400',
     },
     {
       icon: Receipt,
       label: 'Registrar un gasto',
       query: 'Gasté $50 en comida',
+      iconClass: 'bg-error-500/15 text-error-400',
     },
   ];
 
@@ -73,10 +77,10 @@ export function ChatInterface() {
       <ApprovalListener />
       {/* Messages Container */}
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-4 py-6">
+        <div className="mx-auto flex h-full max-w-3xl flex-col px-4 py-6">
           {messages.length === 0 ? (
             // Empty State - Welcome Screen
-            <div className="flex h-full min-h-[60vh] animate-fade-in-up flex-col items-center justify-center text-center">
+            <div className="flex flex-1 animate-fade-in-up flex-col items-center justify-center text-center">
               <div className="relative mb-6">
                 <div className="absolute inset-0 rounded-full bg-primary/20 blur-2xl" />
                 <div className="relative flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-blue-500 shadow-ios">
@@ -92,7 +96,7 @@ export function ChatInterface() {
               </p>
 
               {/* Quick Actions Grid */}
-              <div className="mt-8 grid w-full max-w-sm grid-cols-2 gap-3 sm:max-w-md">
+              <div className="mt-8 grid w-full max-w-lg grid-cols-1 gap-3 sm:grid-cols-2">
                 {quickActions.map((action) => (
                   <button
                     type="button"
@@ -101,19 +105,21 @@ export function ChatInterface() {
                       setInput(action.query);
                     }}
                     className={cn(
-                      'group flex flex-col items-start gap-2.5 rounded-2xl border border-border/60 bg-card p-4 text-left',
-                      'transition-ios shadow-ios-sm hover:border-primary/40 hover:bg-primary/5',
+                      'group flex items-center gap-3 rounded-2xl border border-border bg-secondary/60 p-4 text-left',
+                      'transition-ios hover:border-primary/50 hover:bg-secondary',
                       'focus-ring min-h-[44px]',
                       'hover-lift micro-bounce'
                     )}
                   >
-                    <span className="transition-ios flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 group-hover:bg-primary/15">
-                      <action.icon
-                        className="h-[18px] w-[18px] text-primary"
-                        aria-hidden="true"
-                      />
+                    <span
+                      className={cn(
+                        'transition-ios flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl',
+                        action.iconClass
+                      )}
+                    >
+                      <action.icon className="h-5 w-5" aria-hidden="true" />
                     </span>
-                    <span className="text-[13px] font-medium leading-snug text-foreground/80 group-hover:text-foreground">
+                    <span className="text-sm font-medium leading-snug text-foreground/90 group-hover:text-foreground">
                       {action.label}
                     </span>
                   </button>
@@ -136,7 +142,7 @@ export function ChatInterface() {
                       aria-hidden="true"
                     />
                   </div>
-                  <div className="flex items-center gap-1.5 rounded-2xl rounded-bl-md border border-border/60 bg-card px-4 py-3.5 shadow-ios-sm">
+                  <div className="flex items-center gap-1.5 rounded-2xl rounded-bl-md border border-border bg-secondary/60 px-4 py-3.5 shadow-ios-sm">
                     <div
                       className="h-1.5 w-1.5 animate-bounce rounded-full bg-primary/70"
                       style={{ animationDelay: '0ms' }}

--- a/components/ai/chat-message.tsx
+++ b/components/ai/chat-message.tsx
@@ -5,7 +5,7 @@ import { Sparkles, Wrench, Check } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface ChatMessageProps {
-    message: UIMessage;
+  message: UIMessage;
 }
 
 /**
@@ -14,77 +14,99 @@ interface ChatMessageProps {
  * Supports text messages, tool outputs, and loading states.
  */
 export function ChatMessage({ message }: ChatMessageProps) {
-    const isUser = message.role === 'user';
+  const isUser = message.role === 'user';
 
-    return (
-        <div
-            className={cn(
-                'flex w-full items-end gap-2.5 animate-fade-in-up',
-                isUser ? 'justify-end' : 'justify-start'
-            )}
-        >
-            {/* Assistant Avatar */}
-            {!isUser && (
-                <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary to-blue-500 shadow-ios-sm">
-                    <Sparkles className="h-4 w-4 text-white" aria-hidden="true" />
-                </div>
-            )}
-
-            <div
-                className={cn(
-                    'max-w-[85%] sm:max-w-[70%] rounded-2xl px-4 py-2.5 transition-ios',
-                    isUser
-                        ? 'rounded-br-md bg-primary text-primary-foreground shadow-ios-sm'
-                        : 'rounded-bl-md border border-border/60 bg-card text-card-foreground shadow-ios-sm'
-                )}
-            >
-                {/* Message Content */}
-                <div className="whitespace-pre-wrap text-[15px] leading-relaxed">
-                    {message.parts ? (
-                        message.parts.map((part: any, index: number) => {
-                            // Render text parts
-                            if (part.type === 'text') {
-                                return <span key={index}>{part.text}</span>;
-                            }
-                            // Render tool output when available
-                            if (part.type?.startsWith('tool-') && part.state === 'output-available' && part.output) {
-                                return (
-                                    <div key={index} className="mt-2 rounded-xl border border-border/50 bg-muted/40 p-3">
-                                        <div className="mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
-                                            <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15">
-                                                <Wrench className="h-3 w-3 text-primary" aria-hidden="true" />
-                                            </span>
-                                            <span className="font-medium">{part.type.replace('tool-', '')}</span>
-                                        </div>
-                                        <div className="text-sm">{part.output}</div>
-                                    </div>
-                                );
-                            }
-                            // Ignore step-start and other non-visual types
-                            return null;
-                        })
-                    ) : (
-                        (message as any).content
-                    )}
-                </div>
-
-                {/* Legacy Tool Invocations Display */}
-                {(message as any).toolInvocations && (message as any).toolInvocations.length > 0 && (
-                    <div className="mt-3 space-y-1.5 border-t border-border/50 pt-2">
-                        {(message as any).toolInvocations.map((tool: any, index: number) => (
-                            <div key={index} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15">
-                                    <Wrench className="h-3 w-3 text-primary" aria-hidden="true" />
-                                </span>
-                                <span>{tool.toolName}</span>
-                                {tool.state === 'result' && (
-                                    <Check className="h-3.5 w-3.5 text-success" aria-hidden="true" />
-                                )}
-                            </div>
-                        ))}
-                    </div>
-                )}
-            </div>
+  return (
+    <div
+      className={cn(
+        'flex w-full animate-fade-in-up items-end gap-2.5',
+        isUser ? 'justify-end' : 'justify-start'
+      )}
+    >
+      {/* Assistant Avatar */}
+      {!isUser && (
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary to-blue-500 shadow-ios-sm">
+          <Sparkles className="h-4 w-4 text-white" aria-hidden="true" />
         </div>
-    );
+      )}
+
+      <div
+        className={cn(
+          'transition-ios max-w-[85%] rounded-2xl px-4 py-2.5 sm:max-w-[70%]',
+          isUser
+            ? 'rounded-br-md bg-primary text-primary-foreground shadow-ios-sm'
+            : 'rounded-bl-md border border-border bg-secondary/60 text-foreground shadow-ios-sm'
+        )}
+      >
+        {/* Message Content */}
+        <div className="whitespace-pre-wrap text-[15px] leading-relaxed">
+          {message.parts
+            ? message.parts.map((part: any, index: number) => {
+                // Render text parts
+                if (part.type === 'text') {
+                  return <span key={index}>{part.text}</span>;
+                }
+                // Render tool output when available
+                if (
+                  part.type?.startsWith('tool-') &&
+                  part.state === 'output-available' &&
+                  part.output
+                ) {
+                  return (
+                    <div
+                      key={index}
+                      className="mt-2 rounded-xl border border-border/50 bg-muted/40 p-3"
+                    >
+                      <div className="mb-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15">
+                          <Wrench
+                            className="h-3 w-3 text-primary"
+                            aria-hidden="true"
+                          />
+                        </span>
+                        <span className="font-medium">
+                          {part.type.replace('tool-', '')}
+                        </span>
+                      </div>
+                      <div className="text-sm">{part.output}</div>
+                    </div>
+                  );
+                }
+                // Ignore step-start and other non-visual types
+                return null;
+              })
+            : (message as any).content}
+        </div>
+
+        {/* Legacy Tool Invocations Display */}
+        {(message as any).toolInvocations &&
+          (message as any).toolInvocations.length > 0 && (
+            <div className="mt-3 space-y-1.5 border-t border-border/50 pt-2">
+              {(message as any).toolInvocations.map(
+                (tool: any, index: number) => (
+                  <div
+                    key={index}
+                    className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                  >
+                    <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary/15">
+                      <Wrench
+                        className="h-3 w-3 text-primary"
+                        aria-hidden="true"
+                      />
+                    </span>
+                    <span>{tool.toolName}</span>
+                    {tool.state === 'result' && (
+                      <Check
+                        className="h-3.5 w-3.5 text-success"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </div>
+                )
+              )}
+            </div>
+          )}
+      </div>
+    </div>
+  );
 }

--- a/components/layout/main-layout.tsx
+++ b/components/layout/main-layout.tsx
@@ -55,6 +55,9 @@ function MainLayoutContent({ children }: MainLayoutProps) {
       pathname === '/transactions') &&
     !pathname.includes('/add');
   const hideMobileChrome = pathname.startsWith('/transactions/add');
+  // Pages that manage their own scroll and pin content to the viewport
+  // bottom (e.g. the chat composer) opt out of the padded content wrapper
+  const isFullHeightPage = pathname === '/chat';
 
   return (
     <div
@@ -90,18 +93,23 @@ function MainLayoutContent({ children }: MainLayoutProps) {
           <main
             className={cn(
               'app-shell-main no-horizontal-scroll flex-1 bg-background',
+              isFullHeightPage && 'flex min-h-0 flex-col overflow-hidden',
               isMobile && !hideMobileChrome ? 'pb-24' : ''
             )}
           >
-            <div
-              className={cn(
-                isMobile
-                  ? 'no-horizontal-scroll px-4 py-6' // Mobile app-like padding
-                  : 'no-horizontal-scroll mx-auto max-w-6xl px-6 py-8' // Desktop padding
-              )}
-            >
-              {children}
-            </div>
+            {isFullHeightPage ? (
+              children
+            ) : (
+              <div
+                className={cn(
+                  isMobile
+                    ? 'no-horizontal-scroll px-4 py-6' // Mobile app-like padding
+                    : 'no-horizontal-scroll mx-auto max-w-6xl px-6 py-8' // Desktop padding
+                )}
+              >
+                {children}
+              </div>
+            )}
           </main>
         </div>
       </div>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
Follow-up to #27 — the chat still looked rough in dark mode (user screenshot): black-on-black cards, the empty state floating high with a huge gap above a lonely composer.

### Root cause
`MainLayout` wraps every page in a padded content div with no height, so the chat's `h-full` collapsed — the composer sat at content height instead of the viewport bottom.

### Changes
- **MainLayout**: `/chat` opts out of the padded wrapper; `main` becomes a min-h-0 flex column for it, so the messages own the scroll and the composer pins to the viewport bottom
- **Chat page**: uses the shared `requireAuthenticatedUser()` helper instead of duplicated `getUser`/redirect logic (also enables the e2e auth bypass)
- **Empty state**: centers in the real available height (flex-1 chain)
- **Quick actions**: horizontal cards with per-action color tints (blue/green/amber/red) on `bg-secondary` surfaces that read clearly on dark backgrounds
- **Composer, assistant bubbles, loading indicator**: `border-border` + `bg-secondary/60` for dark-mode contrast

## Verification
- Verified live: dev server + Playwright screenshot in dark mode (1750×793) — composer pinned, content centered, cards visible
- Full Jest suite: 1485 passing / 0 failing
- `tsc --noEmit`: 0 errors
- Pre-push pipeline (supabase + type-check + lint + test:ci + build): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MWZRU7WSTkWSM77jRXdgX9