### PR TITLE
fix(ui): migrate category and goal cards to semantic theme tokens

### DIFF
--- a/components/categories/category-card.tsx
+++ b/components/categories/category-card.tsx
@@ -1,5 +1,4 @@
 import {
-  MoreVertical,
   Edit,
   Trash2,
   Eye,
@@ -77,11 +76,11 @@ export function CategoryCard({
             <IconComponent className="h-5 w-5 text-white" />
           </div>
           <div className="flex min-w-0 flex-1 flex-col">
-            <h3 className="truncate text-base font-semibold text-white">
+            <h3 className="truncate text-base font-semibold text-foreground">
               {category.name}
             </h3>
             {category.subcategories && category.subcategories.length > 0 && (
-              <span className="truncate text-xs text-gray-400">
+              <span className="truncate text-xs text-muted-foreground">
                 {category.subcategories.length} subcategorías
               </span>
             )}
@@ -93,7 +92,7 @@ export function CategoryCard({
             {onView && (
               <button
                 onClick={() => onView(category.id)}
-                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-blue-400/10 hover:text-blue-400"
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-blue-400/10 hover:text-blue-600 dark:hover:text-blue-400"
                 aria-label={`View category ${category.name}`}
               >
                 <Eye className="h-4 w-4" />
@@ -102,7 +101,7 @@ export function CategoryCard({
             {onEdit && (
               <button
                 onClick={() => onEdit(category)}
-                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-yellow-400/10 hover:text-yellow-400"
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-yellow-400/10 hover:text-yellow-600 dark:hover:text-yellow-400"
                 aria-label={`Edit category ${category.name}`}
               >
                 <Edit className="h-4 w-4" />
@@ -111,7 +110,7 @@ export function CategoryCard({
             {onDelete && (
               <button
                 onClick={() => onDelete(category.id)}
-                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-red-400/10 hover:text-red-400"
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-red-400/10 hover:text-red-600 dark:hover:text-red-400"
                 aria-label={`Delete category ${category.name}`}
               >
                 <Trash2 className="h-4 w-4" />
@@ -120,7 +119,7 @@ export function CategoryCard({
             {!category.parentId && onAddSubcategory && (
               <button
                 onClick={() => onAddSubcategory(category.id)}
-                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-gray-700/50 hover:text-white"
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
                 aria-label={`Add subcategory to ${category.name}`}
               >
                 <Plus className="h-4 w-4" />
@@ -133,7 +132,7 @@ export function CategoryCard({
   }
 
   return (
-    <div className="group rounded-xl border border-gray-800 bg-gray-900 p-6 transition-all hover:bg-gray-800/50">
+    <div className="group rounded-xl border border-border bg-card p-6 transition-all hover:bg-muted/50">
       {' '}
       <div className="flex items-start justify-between">
         {/* Category Info */}
@@ -146,51 +145,55 @@ export function CategoryCard({
           </div>
 
           <div className="min-w-0 flex-1">
-            <h3 className="truncate text-lg font-semibold text-white">
+            <h3 className="truncate text-lg font-semibold text-foreground">
               {category.name}
             </h3>
-            <div className="flex items-center space-x-2 text-sm text-gray-400">
+            <div className="flex items-center space-x-2 text-sm text-muted-foreground">
               <span
                 className={`rounded-full px-2 py-1 text-xs ${
                   category.kind === 'INCOME'
-                    ? 'bg-green-400/20 text-green-400'
-                    : 'bg-red-400/20 text-red-400'
+                    ? 'bg-green-400/20 text-green-700 dark:text-green-400'
+                    : 'bg-red-400/20 text-red-700 dark:text-red-400'
                 }`}
               >
                 {category.kind === 'INCOME' ? 'Ingreso' : 'Gasto'}
               </span>
               {category.parentId && (
-                <span className="text-xs text-gray-500">• Subcategoría</span>
+                <span className="text-xs text-muted-foreground/70">
+                  • Subcategoría
+                </span>
               )}
             </div>
 
             {/* Statistics */}
             <div className="mt-2 flex items-center space-x-4 text-sm">
-              <div className="text-gray-300">
+              <div className="text-foreground">
                 <span className="font-medium">
                   {category.transactionCount || 0}
                 </span>
-                <span className="ml-1 text-gray-500">transacciones</span>
+                <span className="ml-1 text-muted-foreground">
+                  transacciones
+                </span>
               </div>
             </div>
 
             {/* Subcategories */}
             {category.subcategories && category.subcategories.length > 0 && (
               <div className="mt-3">
-                <p className="mb-2 text-xs text-gray-500">
+                <p className="mb-2 text-xs text-muted-foreground">
                   {category.subcategories.length} subcategorías
                 </p>
                 <div className="flex flex-wrap gap-1">
                   {category.subcategories.slice(0, 3).map((sub) => (
                     <span
                       key={sub.id}
-                      className="rounded-full bg-gray-700 px-2 py-1 text-xs text-gray-300"
+                      className="rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground"
                     >
                       {sub.name}
                     </span>
                   ))}
                   {category.subcategories.length > 3 && (
-                    <span className="rounded-full bg-gray-700 px-2 py-1 text-xs text-gray-400">
+                    <span className="rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground">
                       +{category.subcategories.length - 3} más
                     </span>
                   )}
@@ -203,7 +206,7 @@ export function CategoryCard({
               <div className="mt-3">
                 <button
                   onClick={() => onAddSubcategory(category.id)}
-                  className="flex min-h-[44px] min-w-[44px] items-center justify-center space-x-1 rounded-full bg-gray-700/50 px-2 py-1 text-xs text-gray-300 transition-colors hover:bg-gray-600/50 hover:text-white"
+                  className="flex min-h-[44px] min-w-[44px] items-center justify-center space-x-1 rounded-full bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   aria-label={`Add subcategory to ${category.name}`}
                 >
                   <Plus className="h-3 w-3" />
@@ -219,7 +222,7 @@ export function CategoryCard({
           {onView && (
             <button
               onClick={() => onView(category.id)}
-              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-blue-400/10 hover:text-blue-400"
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-blue-400/10 hover:text-blue-600 dark:hover:text-blue-400"
               aria-label={`View category ${category.name}`}
             >
               <Eye className="h-4 w-4" />
@@ -228,7 +231,7 @@ export function CategoryCard({
           {onEdit && (
             <button
               onClick={() => onEdit(category)}
-              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-yellow-400/10 hover:text-yellow-400"
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-yellow-400/10 hover:text-yellow-600 dark:hover:text-yellow-400"
               aria-label={`Edit category ${category.name}`}
             >
               <Edit className="h-4 w-4" />
@@ -237,7 +240,7 @@ export function CategoryCard({
           {onDelete && (
             <button
               onClick={() => onDelete(category.id)}
-              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-400 transition-colors hover:bg-red-400/10 hover:text-red-400"
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-red-400/10 hover:text-red-600 dark:hover:text-red-400"
               aria-label={`Delete category ${category.name}`}
             >
               <Trash2 className="h-4 w-4" />

--- a/components/goals/goal-card.tsx
+++ b/components/goals/goal-card.tsx
@@ -89,7 +89,7 @@ export function GoalCard({
     if (isCompleted) return 'bg-green-500/10 border-green-500/20';
     if (isOverdue) return 'bg-red-500/10 border-red-500/20';
     if (isNearDeadline) return 'bg-yellow-500/10 border-yellow-500/20';
-    return 'bg-gray-900 border-gray-800';
+    return 'bg-card border-border';
   };
 
   return (
@@ -99,18 +99,18 @@ export function GoalCard({
       <div className="mb-4 flex items-start justify-between">
         <div className="min-w-0 flex-1">
           <div className="mb-1 flex items-center space-x-2">
-            <Target className="h-5 w-5 text-blue-400" />
-            <h3 className="truncate text-lg font-semibold text-white">
+            <Target className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            <h3 className="truncate text-lg font-semibold text-foreground">
               {goal.name}
             </h3>
             {isCompleted && <CheckCircle className="h-5 w-5 text-green-500" />}
           </div>
           {goal.description && (
-            <p className="mb-2 line-clamp-2 text-sm text-gray-400">
+            <p className="mb-2 line-clamp-2 text-sm text-muted-foreground">
               {goal.description}
             </p>
           )}
-          <div className="flex items-center space-x-4 text-sm text-gray-400">
+          <div className="flex items-center space-x-4 text-sm text-muted-foreground">
             {account && <span>{account.name}</span>}
             {goal.targetDate && (
               <div className="flex items-center space-x-1">
@@ -136,7 +136,7 @@ export function GoalCard({
             {onView && (
               <button
                 onClick={() => onView(goal.id)}
-                className="rounded p-1 text-gray-400 transition-colors hover:bg-blue-400/10 hover:text-blue-400"
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-blue-400/10 hover:text-blue-600 dark:hover:text-blue-400"
                 title="Ver detalles"
               >
                 <Eye className="h-4 w-4" />
@@ -145,7 +145,7 @@ export function GoalCard({
             {onEdit && (
               <button
                 onClick={() => onEdit(goal)}
-                className="rounded p-1 text-gray-400 transition-colors hover:bg-yellow-400/10 hover:text-yellow-400"
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-yellow-400/10 hover:text-yellow-600 dark:hover:text-yellow-400"
                 title="Editar meta"
               >
                 <Edit className="h-4 w-4" />
@@ -154,7 +154,7 @@ export function GoalCard({
             {onDelete && (
               <button
                 onClick={() => onDelete(goal.id)}
-                className="rounded p-1 text-gray-400 transition-colors hover:bg-red-400/10 hover:text-red-400"
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-red-400/10 hover:text-red-600 dark:hover:text-red-400"
                 title="Eliminar meta"
               >
                 <Trash2 className="h-4 w-4" />
@@ -166,22 +166,22 @@ export function GoalCard({
 
       <div className="mb-4">
         <div className="mb-2 flex justify-between text-sm">
-          <span className="text-gray-400">Progreso</span>
+          <span className="text-muted-foreground">Progreso</span>
           <span
             className={`font-medium ${
               isCompleted
-                ? 'text-green-400'
+                ? 'text-green-600 dark:text-green-400'
                 : isOverdue
-                  ? 'text-red-400'
+                  ? 'text-red-600 dark:text-red-400'
                   : isNearDeadline
-                    ? 'text-yellow-400'
-                    : 'text-blue-400'
+                    ? 'text-yellow-600 dark:text-yellow-400'
+                    : 'text-blue-600 dark:text-blue-400'
             }`}
           >
             {Math.round(percentage)}%
           </span>
         </div>
-        <div className="h-3 w-full rounded-full bg-gray-700">
+        <div className="h-3 w-full rounded-full bg-muted">
           <div
             className={`h-3 rounded-full transition-all duration-300 ${getProgressColor()}`}
             style={{ width: `${Math.min(percentage, 100)}%` }}
@@ -191,18 +191,20 @@ export function GoalCard({
 
       <div className="mb-4 grid grid-cols-2 gap-4">
         <div>
-          <p className="mb-1 text-sm text-gray-400">Ahorrado</p>
-          <p className="text-xl font-bold text-white">
+          <p className="mb-1 text-sm text-muted-foreground">Ahorrado</p>
+          <p className="text-xl font-bold text-foreground">
             {formatCurrency(currentAmount)}
           </p>
         </div>
         <div>
-          <p className="mb-1 text-sm text-gray-400">
+          <p className="mb-1 text-sm text-muted-foreground">
             {isCompleted ? 'Meta Alcanzada' : 'Falta'}
           </p>
           <p
             className={`text-xl font-bold ${
-              isCompleted ? 'text-green-400' : 'text-blue-400'
+              isCompleted
+                ? 'text-green-600 dark:text-green-400'
+                : 'text-blue-600 dark:text-blue-400'
             }`}
           >
             {isCompleted ? '¡Completado!' : formatCurrency(remainingAmount)}
@@ -216,10 +218,10 @@ export function GoalCard({
             isCompleted
               ? 'border-green-500/20 bg-green-500/10'
               : isOverdue
-                ? 'border-red-500/20 bg-red-500/10 text-red-300'
+                ? 'border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-300'
                 : isNearDeadline
-                  ? 'border-yellow-500/20 bg-yellow-500/10 text-yellow-300'
-                  : 'border-blue-500/20 bg-blue-500/10 text-blue-300'
+                  ? 'border-yellow-500/20 bg-yellow-500/10 text-yellow-700 dark:text-yellow-300'
+                  : 'border-blue-500/20 bg-blue-500/10 text-blue-700 dark:text-blue-300'
           }`}
         >
           <div className="flex items-center space-x-2 text-sm">
@@ -236,7 +238,7 @@ export function GoalCard({
       )}
 
       {isLinkedAccountGoal && (
-        <div className="mb-4 flex items-start space-x-2 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3 text-sm text-emerald-200">
+        <div className="mb-4 flex items-start space-x-2 rounded-lg border border-emerald-500/20 bg-emerald-500/10 p-3 text-sm text-emerald-800 dark:text-emerald-200">
           <Wallet className="mt-0.5 h-4 w-4 shrink-0" />
           <span>
             El progreso se sincroniza con el saldo de la cuenta vinculada. Los
@@ -268,7 +270,7 @@ export function GoalCard({
         </button>
       )}
 
-      <div className="mt-2 flex justify-between text-xs text-gray-500">
+      <div className="mt-2 flex justify-between text-xs text-muted-foreground/70">
         <span>{formatCurrency(0)}</span>
         <span>{formatCurrency(targetAmount)}</span>
       </div>

--- a/tests/components/category-card.test.tsx
+++ b/tests/components/category-card.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react';
+import { CategoryCard } from '@/components/categories/category-card';
+import type { CategoryCardCategory } from '@/components/categories/category-card';
+import { CategoryKind } from '@/types';
+
+const baseCategory: CategoryCardCategory = {
+  id: 'cat-1',
+  name: 'Comida',
+  kind: CategoryKind.EXPENSE,
+  color: '#ef4444',
+  icon: 'UtensilsCrossed',
+  active: true,
+  userId: null,
+  isDefault: false,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  transactionCount: 3,
+  subcategories: [
+    {
+      id: 'cat-2',
+      name: 'Delivery',
+      kind: CategoryKind.EXPENSE,
+      color: '#ef4444',
+      icon: 'UtensilsCrossed',
+      parentId: 'cat-1',
+      active: true,
+      userId: null,
+      isDefault: false,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+};
+
+// The design system is theme-aware through semantic tokens (bg-card,
+// border-border, text-foreground, bg-muted). Hardcoded gray-* palette
+// classes render as dark surfaces in light mode, which is the regression
+// this suite guards against.
+const GRAY_CLASS = /(?:^|\s)(?:bg|border|text|hover:bg|hover:text)-gray-\d/;
+
+function grayClassedElements(root: HTMLElement): string[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('*'))
+    .map((el) => el.className)
+    .filter(
+      (cls): cls is string => typeof cls === 'string' && GRAY_CLASS.test(cls)
+    );
+}
+
+describe('CategoryCard theme tokens', () => {
+  it('grid view uses semantic card tokens instead of hardcoded grays', () => {
+    const { container } = render(
+      <CategoryCard
+        category={baseCategory}
+        viewMode="grid"
+        onView={() => {}}
+        onEdit={() => {}}
+        onAddSubcategory={() => {}}
+      />
+    );
+
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain('bg-card');
+    expect(card.className).toContain('border-border');
+    expect(grayClassedElements(container)).toEqual([]);
+  });
+
+  it('list view uses semantic tokens instead of hardcoded grays', () => {
+    const { container } = render(
+      <CategoryCard
+        category={baseCategory}
+        viewMode="list"
+        onView={() => {}}
+        onAddSubcategory={() => {}}
+      />
+    );
+
+    expect(grayClassedElements(container)).toEqual([]);
+  });
+});

--- a/tests/components/goals/goal-card.test.tsx
+++ b/tests/components/goals/goal-card.test.tsx
@@ -47,4 +47,21 @@ describe('GoalCard', () => {
       screen.getByRole('button', { name: /actualizando/i })
     ).toBeDisabled();
   });
+
+  it('uses semantic theme tokens instead of hardcoded grays', () => {
+    const { container } = render(<GoalCard goal={baseGoal} />);
+
+    const card = container.firstElementChild as HTMLElement;
+    expect(card.className).toContain('bg-card');
+    expect(card.className).toContain('border-border');
+
+    const grayClassed = Array.from(container.querySelectorAll<HTMLElement>('*'))
+      .map((el) => el.className)
+      .filter(
+        (cls): cls is string =>
+          typeof cls === 'string' &&
+          /(?:^|\s)(?:bg|border|text|hover:bg|hover:text)-gray-\d/.test(cls)
+      );
+    expect(grayClassed).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #32

## Descripcion

Los grids de Categorias y Goals tenian la paleta oscura hardcodeada (bg-gray-900, border-gray-800, text-white/gray-*) y se veian como tarjetas negras en modo claro. Se migran ambos cards a los tokens semanticos del design system (bg-card, border-border, text-foreground, text-muted-foreground, bg-muted), que son theme-aware, y los acentos ilegibles en claro (text-red-300, text-emerald-200, text-yellow-400) pasan a duales light/dark (p. ej. text-red-700 dark:text-red-300).

Se conserva text-white en los iconos sobre circulos rellenos con el color de la categoria (correcto en ambos temas) y en los CTAs solidos (bg-blue-600/emerald-600). Review nativo: lineage `review-6039ff960bf0cdf7` aprobado (0 hallazgos), gates pre-commit/pre-push/pre-pr en allow.

## Cambios principales

- `components/categories/category-card.tsx`: vista grid migrada a tokens (la vista list ya los usaba); chips de subcategorias y hovers a bg-muted; import MoreVertical sin uso eliminado.
- `components/goals/goal-card.tsx`: superficie default a bg-card/border-border; track de progreso a bg-muted; textos de estado y banners con duales light/dark.
- `tests/components/category-card.test.tsx` (nuevo) y `tests/components/goals/goal-card.test.tsx`: tests de regresion que asertan tokens semanticos en el root y cero clases gray-* renderizadas (RED genuino: fallaban antes de la migracion).

## Checklist minimo

- [x] Ejecute pruebas relevantes (`npm run type-check`, `npm run lint`, `npm test -- --runInBand`, `npm run build`).
- [x] Verifique que no se incluyen secretos (tokens, passwords, `.env`, credenciales).
- [x] Actualice documentacion si aplica.
- [x] Revise impacto en DB/API (migraciones, contratos, compatibilidad hacia atras).

## Impacto en DB/API

- DB: ninguno.
- API: ninguno — cambio exclusivamente de clases CSS y tests.

## Evidencia de pruebas

- 3 tests nuevos de tokens: RED antes de la migracion, GREEN despues; suites relacionadas 4/4 (20 tests).
- Suite completa: 1483 tests, 0 fallos. Type-check exit 0. Prettier/oxlint limpios en los 4 archivos.
- Hook pre-push completo en verde (tests + build).