### PR TITLE
fix(categories): count transactions across the category subtree

### DIFF
--- a/app/categories/page.tsx
+++ b/app/categories/page.tsx
@@ -11,6 +11,7 @@ import type { CategoryCardCategory } from '@/components/categories';
 import { Button } from '@/components/ui';
 import { formatCurrencyWithBCV } from '@/lib/currency-ves';
 import { formatCurrency } from '@/lib/money';
+import { getDescendantIds } from '@/lib/categories';
 import { useCurrencyConverter } from '@/hooks/use-currency-converter';
 import { useModal } from '@/hooks';
 import { useOptimizedData } from '@/hooks/use-optimized-data';
@@ -115,10 +116,19 @@ export default function CategoriesPage() {
     });
 
     return filteredCategories.map((category) => {
+      // Direct-only transactions still drive the per-currency totals below.
       const categoryTransactions = rawTransactions.filter(
         (t) => t.categoryId === category.id
       );
-      const transactionCount = categoryTransactions.length;
+      // The visible count spans the whole subtree (category + descendants) so
+      // it matches the list the drilldown opens with, whose default view
+      // includes subcategories. Same walk as the drilldown (lib/categories).
+      const subtreeIds = new Set(
+        getDescendantIds(category.id, filteredCategories)
+      );
+      const transactionCount = rawTransactions.filter((t) =>
+        t.categoryId ? subtreeIds.has(t.categoryId) : false
+      ).length;
 
       // Totals per currency in minor units
       const totalVESMinor = categoryTransactions
@@ -588,7 +598,9 @@ export default function CategoriesPage() {
       {drilldownCategory && (
         <CategoryTransactionDrilldown
           category={drilldownCategory}
-          categories={rawCategories || []}
+          // Same visibility-filtered universe the card counts walk, so the
+          // panel's descendant scope can never diverge from the card number.
+          categories={categories}
           repository={repository}
           refreshKey={refreshKey}
           onClose={() => setDrilldownCategory(null)}

--- a/components/categories/category-transaction-drilldown.tsx
+++ b/components/categories/category-transaction-drilldown.tsx
@@ -10,19 +10,7 @@ import type {
   TransactionFilters,
   PaginationParams,
 } from '@/types';
-
-function getDescendantIds(
-  id: string,
-  cats: Category[],
-  visited = new Set<string>()
-): string[] {
-  if (visited.has(id)) return [];
-  visited.add(id);
-  const ids = [id];
-  for (const c of cats)
-    if (c.parentId === id) ids.push(...getDescendantIds(c.id, cats, visited));
-  return ids;
-}
+import { getDescendantIds } from '@/lib/categories';
 
 const PAGE_SIZE = 50;
 

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -1,0 +1,23 @@
+import type { Category } from '@/types';
+
+/**
+ * Collect a category id plus all of its transitive descendant ids.
+ *
+ * Single source of truth for hierarchy-aware category scoping: the drilldown
+ * panel (whose default view includes subcategories) and the category card
+ * transaction count both use this walk, so the count shown on a card always
+ * matches the list the drilldown opens with. The visited set guards against
+ * cycles in corrupted parentId chains.
+ */
+export function getDescendantIds(
+  id: string,
+  cats: Category[],
+  visited = new Set<string>()
+): string[] {
+  if (visited.has(id)) return [];
+  visited.add(id);
+  const ids = [id];
+  for (const c of cats)
+    if (c.parentId === id) ids.push(...getDescendantIds(c.id, cats, visited));
+  return ids;
+}

--- a/tests/app/categories-page.test.tsx
+++ b/tests/app/categories-page.test.tsx
@@ -279,4 +279,72 @@ describe('CategoriesPage Slice 2', () => {
     expect(formatCurrency).toHaveBeenCalledWith(1050, 'USD');
     expect(screen.getAllByText('$SENTINEL$').length).toBeGreaterThanOrEqual(1);
   });
+
+  // Card counts must match what the drilldown opens by default: the category
+  // PLUS its descendants. A parent with 3 direct and 4 subcategory
+  // transactions must show 7, not 3.
+  it('card transaction count includes descendant categories', () => {
+    setupMocks(
+      [
+        cat({ id: 'p1', name: 'Food' }),
+        cat({ id: 'c1', name: 'Delivery', parentId: 'p1' }),
+      ],
+      [
+        tx({ id: 'd1', categoryId: 'p1' }),
+        tx({ id: 'd2', categoryId: 'p1' }),
+        tx({ id: 'd3', categoryId: 'p1' }),
+        tx({ id: 's1', categoryId: 'c1' }),
+        tx({ id: 's2', categoryId: 'c1' }),
+        tx({ id: 's3', categoryId: 'c1' }),
+        tx({ id: 's4', categoryId: 'c1' }),
+      ]
+    );
+    render(<Page />);
+
+    // Parent card: subtree count (3 direct + 4 in Delivery).
+    expect(screen.getByText('7')).toBeInTheDocument();
+    // Child card keeps its own subtree count (4, no descendants).
+    expect(screen.getByText('4')).toBeInTheDocument();
+    // The direct-only parent count must be gone.
+    expect(screen.queryByText('3')).not.toBeInTheDocument();
+  });
+
+  // Card count and drilldown must walk the SAME visibility-filtered category
+  // universe: a foreign-user child (data-integrity edge the service does not
+  // prevent) is excluded from the count AND from the categories the drilldown
+  // receives, so the pair cannot diverge again.
+  it('count and drilldown share the visibility-filtered category universe', async () => {
+    setupMocks(
+      [
+        cat({ id: 'p1', name: 'Food' }),
+        cat({ id: 'cx', name: 'Foreign', parentId: 'p1', userId: 'u2' }),
+      ],
+      [
+        tx({ id: 'd1', categoryId: 'p1' }),
+        tx({ id: 'd2', categoryId: 'p1' }),
+        tx({ id: 'd3', categoryId: 'p1' }),
+        tx({ id: 'f1', categoryId: 'cx' }),
+        tx({ id: 'f2', categoryId: 'cx' }),
+        tx({ id: 'f3', categoryId: 'cx' }),
+        tx({ id: 'f4', categoryId: 'cx' }),
+      ]
+    );
+    render(<Page />);
+
+    // Foreign child is outside the user's visible universe: count stays 3.
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.queryByText('7')).not.toBeInTheDocument();
+
+    // Opening the drilldown hands it the same filtered universe.
+    await userEvent.click(
+      screen.getByRole('button', { name: /view category food/i })
+    );
+    const {
+      CategoryTransactionDrilldown,
+    } = require('@/components/categories/category-transaction-drilldown');
+    const lastProps = CategoryTransactionDrilldown.mock.calls.at(-1)?.[0] ?? {};
+    const ids = (lastProps.categories ?? []).map((c: Category) => c.id);
+    expect(ids).toContain('p1');
+    expect(ids).not.toContain('cx');
+  });
 });


### PR DESCRIPTION
Closes #34

## Descripcion

Las cards de categorias mostraban el conteo de transacciones directas (p. ej. 3), pero el drilldown que abren incluye subcategorias por defecto (p. ej. 7 filas). Ahora el contador de la card abarca la categoria mas todos sus descendientes, usando el mismo walk cycle-safe que usa el drilldown.

Ademas, review interno detecto una segunda fuente de divergencia y se cierra en el mismo PR: la card contaba sobre la lista filtrada por visibilidad del usuario, pero el drilldown recibia `rawCategories` sin filtrar — un hijo cross-owner (edge de integridad que el service no previene) podia volver a desincronizar card y panel. Ahora ambos caminan el MISMO universo filtrado.

Review nativo: lineage `review-f03d6232ce44485f` aprobado (0 hallazgos), gates pre-commit/pre-push/pre-pr en allow.

## Cambios principales

- `lib/categories.ts` (nuevo): `getDescendantIds` extraido del drilldown como unica fuente de verdad del scoping jerarquico.
- `app/categories/page.tsx`: conteo por subarbol en las stats de card; el drilldown recibe la lista filtrada por visibilidad en lugar de `rawCategories`. Los totales por moneda de la card siguen siendo directos (se computan pero no se renderizan).
- `components/categories/category-transaction-drilldown.tsx`: importa el helper compartido (se elimina la copia local).
- `tests/app/categories-page.test.tsx`: 2 tests de regresion con RED genuino y verificados por mutacion (conteo por subarbol 3+4=7; universo compartido card/panel con hijo cross-owner excluido de ambos).

## Checklist minimo

- [x] Ejecute pruebas relevantes (`npm run type-check`, `npm run lint`, `npm test -- --runInBand`, `npm run build`).
- [x] Verifique que no se incluyen secretos (tokens, passwords, `.env`, credenciales).
- [x] Actualice documentacion si aplica.
- [x] Revise impacto en DB/API (migraciones, contratos, compatibilidad hacia atras).

## Impacto en DB/API

- DB: ninguno.
- API: ninguno — logica de presentacion y helper puro compartido.

## Evidencia de pruebas

- 2 tests nuevos: RED antes del fix, GREEN despues; ambos fallan bajo mutacion (revertir el filtro directo o el prop `rawCategories`) y se re-verificaron en verde tras revertir.
- Suites afectadas 3/3 (19 tests). Suite completa: 1507 tests, 0 fallos. Type-check, prettier y oxlint limpios.
- Hook pre-push completo en verde (tests + build).